### PR TITLE
feat: implement unfollow user API

### DIFF
--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -668,6 +668,59 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Allows an authenticated user to unfollow another user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Unfollow a user",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID to unfollow",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.UnfollowResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    }
+                }
             }
         }
     },
@@ -857,6 +910,14 @@ const docTemplate = `{
             }
         },
         "github_com_billykore_project-one_internal_api_dto.RegisterResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_billykore_project-one_internal_api_dto.UnfollowResponse": {
             "type": "object",
             "properties": {
                 "message": {

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -662,6 +662,59 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Allows an authenticated user to unfollow another user.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Unfollow a user",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "User ID to unfollow",
+                        "name": "userId",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.UnfollowResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    }
+                }
             }
         }
     },
@@ -851,6 +904,14 @@
             }
         },
         "github_com_billykore_project-one_internal_api_dto.RegisterResponse": {
+            "type": "object",
+            "properties": {
+                "message": {
+                    "type": "string"
+                }
+            }
+        },
+        "github_com_billykore_project-one_internal_api_dto.UnfollowResponse": {
             "type": "object",
             "properties": {
                 "message": {

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -127,6 +127,11 @@ definitions:
       message:
         type: string
     type: object
+  github_com_billykore_project-one_internal_api_dto.UnfollowResponse:
+    properties:
+      message:
+        type: string
+    type: object
   github_com_billykore_project-one_internal_api_dto.UpdatePostRequest:
     properties:
       content:
@@ -340,6 +345,40 @@ paths:
       tags:
       - posts
   /users/{userId}/follow:
+    delete:
+      consumes:
+      - application/json
+      description: Allows an authenticated user to unfollow another user.
+      parameters:
+      - description: User ID to unfollow
+        in: path
+        name: userId
+        required: true
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_billykore_project-one_internal_api_dto.UnfollowResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Unfollow a user
+      tags:
+      - users
     post:
       consumes:
       - application/json

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -92,6 +92,7 @@ func main() {
 	e.GET("/users/me/following", userHdl.GetFollowing, middleware.Authorize(tokenSvc))
 	e.GET("/users/me/followers", userHdl.GetFollowers, middleware.Authorize(tokenSvc))
 	e.POST("/users/:userId/follow", userHdl.HandleFollow, middleware.Authorize(tokenSvc))
+	e.DELETE("/users/:userId/follow", userHdl.HandleUnfollow, middleware.Authorize(tokenSvc))
 	e.POST("/posts", postHdl.CreatePost, middleware.Authorize(tokenSvc))
 	e.GET("/posts", postHdl.GetPosts, middleware.Authorize(tokenSvc))
 	e.GET("/posts/:id", postHdl.GetPostByID, middleware.Authorize(tokenSvc))

--- a/internal/adapters/repository/follow_repository.go
+++ b/internal/adapters/repository/follow_repository.go
@@ -82,3 +82,16 @@ func (r *followRepository) GetFollowers(ctx context.Context, followedID int, lim
 
 	return results, err
 }
+
+func (r *followRepository) Delete(ctx context.Context, followerID, followedID int) error {
+	result := r.db.WithContext(ctx).
+		Where("follower_id = ? AND followed_id = ?", followerID, followedID).
+		Delete(&followModel{})
+	if result.Error != nil {
+		return result.Error
+	}
+	if result.RowsAffected == 0 {
+		return domain.ErrNotFollowing
+	}
+	return nil
+}

--- a/internal/api/dto/user_dto.go
+++ b/internal/api/dto/user_dto.go
@@ -63,6 +63,11 @@ type FollowerResponse struct {
 	IsMutual   bool   `json:"is_mutual"`
 }
 
+// UnfollowResponse is the response body for a successful unfollow action.
+type UnfollowResponse struct {
+	Message string `json:"message"`
+}
+
 // FollowResponse is the response body for a successful follow action.
 type FollowResponse struct {
 	Message string     `json:"message"`

--- a/internal/api/handler/user_handler.go
+++ b/internal/api/handler/user_handler.go
@@ -221,8 +221,11 @@ func (h *UserHandler) HandleFollow(c echo.Context) error {
 
 	follow, err := h.followUseCase.Follow(c.Request().Context(), followerID, followedID)
 	if err != nil {
-		if errors.Is(err, domain.ErrCannotFollowSelf) || errors.Is(err, domain.ErrAlreadyFollowing) {
-			return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: err.Error()})
+		if errors.Is(err, domain.ErrCannotFollowSelf) {
+			return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: domain.ErrCannotFollowSelf.Error()})
+		}
+		if errors.Is(err, domain.ErrAlreadyFollowing) {
+			return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: domain.ErrAlreadyFollowing.Error()})
 		}
 		if errors.Is(err, domain.ErrUserNotFound) {
 			return c.JSON(http.StatusNotFound, dto.ErrorResponse{Error: "User not found"})
@@ -267,15 +270,18 @@ func (h *UserHandler) HandleUnfollow(c echo.Context) error {
 
 	err = h.followUseCase.Unfollow(c.Request().Context(), followerID, followedID)
 	if err != nil {
-		if errors.Is(err, domain.ErrCannotUnfollowSelf) || errors.Is(err, domain.ErrNotFollowing) {
-			return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: err.Error()})
+		if errors.Is(err, domain.ErrCannotUnfollowSelf) {
+			return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: domain.ErrCannotUnfollowSelf.Error()})
+		}
+		if errors.Is(err, domain.ErrNotFollowing) {
+			return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: domain.ErrNotFollowing.Error()})
 		}
 		h.log.Error(c.Request().Context(), "unfollow failed", "followerID", followerID, "followedID", followedID, "error", err)
 		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Error: "Something went wrong"})
 	}
 
 	return c.JSON(http.StatusOK, dto.UnfollowResponse{
-		Message: "Success unfollowed this user.",
+		Message: "Successfully unfollowed this user.",
 	})
 }
 

--- a/internal/api/handler/user_handler.go
+++ b/internal/api/handler/user_handler.go
@@ -240,6 +240,45 @@ func (h *UserHandler) HandleFollow(c echo.Context) error {
 	})
 }
 
+// HandleUnfollow handles the DELETE /users/{userId}/follow endpoint.
+//
+//	@Summary		Unfollow a user
+//	@Description	Allows an authenticated user to unfollow another user.
+//	@Tags			users
+//	@Accept			json
+//	@Produce		json
+//	@Param			userId	path		int	true	"User ID to unfollow"
+//	@Success		200		{object}	dto.UnfollowResponse
+//	@Failure		400		{object}	dto.ErrorResponse
+//	@Failure		401		{object}	dto.ErrorResponse
+//	@Failure		500		{object}	dto.ErrorResponse
+//	@Security		BearerAuth
+//	@Router			/users/{userId}/follow [delete]
+func (h *UserHandler) HandleUnfollow(c echo.Context) error {
+	followerID, ok := c.Get("userID").(int)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, dto.ErrorResponse{Error: "Unauthorized"})
+	}
+
+	followedID, err := strconv.Atoi(c.Param("userId"))
+	if err != nil || followedID <= 0 {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: "Invalid user ID"})
+	}
+
+	err = h.followUseCase.Unfollow(c.Request().Context(), followerID, followedID)
+	if err != nil {
+		if errors.Is(err, domain.ErrCannotUnfollowSelf) || errors.Is(err, domain.ErrNotFollowing) {
+			return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: err.Error()})
+		}
+		h.log.Error(c.Request().Context(), "unfollow failed", "followerID", followerID, "followedID", followedID, "error", err)
+		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Error: "Something went wrong"})
+	}
+
+	return c.JSON(http.StatusOK, dto.UnfollowResponse{
+		Message: "Success unfollowed this user.",
+	})
+}
+
 // GetFollowing handles the GET /users/me/following endpoint.
 //
 //	@Summary		Get following list

--- a/internal/core/domain/user.go
+++ b/internal/core/domain/user.go
@@ -25,6 +25,10 @@ var (
 	ErrAlreadyFollowing = errors.New("already following this user")
 	// ErrCannotFollowSelf is returned when a user tries to follow themselves.
 	ErrCannotFollowSelf = errors.New("cannot follow yourself")
+	// ErrNotFollowing is returned when a user tries to unfollow someone they are not following.
+	ErrNotFollowing = errors.New("not following this user")
+	// ErrCannotUnfollowSelf is returned when a user tries to unfollow themselves.
+	ErrCannotUnfollowSelf = errors.New("cannot unfollow yourself")
 )
 
 // User is the core domain entity representing a user in the system.

--- a/internal/core/ports/follow.go
+++ b/internal/core/ports/follow.go
@@ -16,6 +16,8 @@ type FollowRepository interface {
 	GetFollowing(ctx context.Context, followerID int, limit, offset int) ([]domain.Following, error)
 	// GetFollowers fetches the paginated list of users following a specific user.
 	GetFollowers(ctx context.Context, followedID int, limit, offset int) ([]domain.Follower, error)
+	// Delete removes an existing follow relationship.
+	Delete(ctx context.Context, followerID, followedID int) error
 }
 
 // FollowUseCase defines the interface for follow-related business logic.
@@ -26,4 +28,6 @@ type FollowUseCase interface {
 	GetFollowing(ctx context.Context, followerID int, limit, offset int) ([]domain.Following, error)
 	// GetFollowers handles the logic for getting the followers list of a user.
 	GetFollowers(ctx context.Context, followedID int, limit, offset int) ([]domain.Follower, error)
+	// Unfollow handles the logic for a user unfollowing another user.
+	Unfollow(ctx context.Context, followerID, followedID int) error
 }

--- a/internal/core/usecase/follow_usecase.go
+++ b/internal/core/usecase/follow_usecase.go
@@ -41,6 +41,18 @@ func (u *followUseCase) Follow(ctx context.Context, followerID, followedID int) 
 	return follow, nil
 }
 
+func (u *followUseCase) Unfollow(ctx context.Context, followerID, followedID int) error {
+	if followerID == followedID {
+		return domain.ErrCannotUnfollowSelf
+	}
+
+	if err := u.followRepo.Delete(ctx, followerID, followedID); err != nil {
+		return fmt.Errorf("delete follow: %w", err)
+	}
+
+	return nil
+}
+
 func (u *followUseCase) GetFollowing(ctx context.Context, followerID int, limit, offset int) ([]domain.Following, error) {
 	if limit <= 0 {
 		limit = 10

--- a/internal/core/usecase/follow_usecase_test.go
+++ b/internal/core/usecase/follow_usecase_test.go
@@ -68,6 +68,46 @@ func TestFollowUseCase_Follow(t *testing.T) {
 	})
 }
 
+func TestFollowUseCase_Unfollow(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockFollowRepo := mocks.NewMockFollowRepository(ctrl)
+	mockUserRepo := mocks.NewMockUserRepository(ctrl)
+	svc := NewFollowUseCase(mockFollowRepo, mockUserRepo)
+
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		followerID := 1
+		followedID := 2
+
+		mockFollowRepo.EXPECT().Delete(ctx, followerID, followedID).Return(nil)
+
+		err := svc.Unfollow(ctx, followerID, followedID)
+
+		assert.NoError(t, err)
+	})
+
+	t.Run("cannot unfollow self", func(t *testing.T) {
+		userID := 1
+		err := svc.Unfollow(ctx, userID, userID)
+
+		assert.ErrorIs(t, err, domain.ErrCannotUnfollowSelf)
+	})
+
+	t.Run("not following", func(t *testing.T) {
+		followerID := 1
+		followedID := 2
+
+		mockFollowRepo.EXPECT().Delete(ctx, followerID, followedID).Return(domain.ErrNotFollowing)
+
+		err := svc.Unfollow(ctx, followerID, followedID)
+
+		assert.ErrorIs(t, err, domain.ErrNotFollowing)
+	})
+}
+
 func TestFollowUseCase_GetFollowing(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()

--- a/internal/core/usecase/mocks/mock_follow.go
+++ b/internal/core/usecase/mocks/mock_follow.go
@@ -55,6 +55,20 @@ func (mr *MockFollowRepositoryMockRecorder) Create(ctx, follow any) *gomock.Call
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockFollowRepository)(nil).Create), ctx, follow)
 }
 
+// Delete mocks base method.
+func (m *MockFollowRepository) Delete(ctx context.Context, followerID, followedID int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, followerID, followedID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockFollowRepositoryMockRecorder) Delete(ctx, followerID, followedID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockFollowRepository)(nil).Delete), ctx, followerID, followedID)
+}
+
 // GetFollowers mocks base method.
 func (m *MockFollowRepository) GetFollowers(ctx context.Context, followedID, limit, offset int) ([]domain.Follower, error) {
 	m.ctrl.T.Helper()
@@ -167,4 +181,18 @@ func (m *MockFollowUseCase) GetFollowing(ctx context.Context, followerID, limit,
 func (mr *MockFollowUseCaseMockRecorder) GetFollowing(ctx, followerID, limit, offset any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFollowing", reflect.TypeOf((*MockFollowUseCase)(nil).GetFollowing), ctx, followerID, limit, offset)
+}
+
+// Unfollow mocks base method.
+func (m *MockFollowUseCase) Unfollow(ctx context.Context, followerID, followedID int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Unfollow", ctx, followerID, followedID)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Unfollow indicates an expected call of Unfollow.
+func (mr *MockFollowUseCaseMockRecorder) Unfollow(ctx, followerID, followedID any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unfollow", reflect.TypeOf((*MockFollowUseCase)(nil).Unfollow), ctx, followerID, followedID)
 }


### PR DESCRIPTION
This PR implements the unfollow user API.

Summary of changes:
- Added ErrNotFollowing and ErrCannotUnfollowSelf to domain errors.
- Added Delete method to FollowRepository and implemented it in the repository layer.
- Added Unfollow method to FollowUseCase and implemented it in the use case layer.
- Added HandleUnfollow to UserHandler and registered the route DELETE /users/:userId/follow.
- Added unit tests for the unfollow use case.
- Regenerated mocks and Swagger documentation.