### PR TITLE
feat: add GET /users/:username endpoint

### DIFF
--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -711,6 +711,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
                         }
                     },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {

--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -615,6 +615,56 @@ const docTemplate = `{
                 }
             }
         },
+        "/users/{username}": {
+            "get": {
+                "description": "Get the profile of a user by their username.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Get user profile",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.UserResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/users/{username}/follow": {
             "post": {
                 "security": [

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -705,6 +705,12 @@
                             "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
                         }
                     },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    },
                     "500": {
                         "description": "Internal Server Error",
                         "schema": {

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -609,6 +609,56 @@
                 }
             }
         },
+        "/users/{username}": {
+            "get": {
+                "description": "Get the profile of a user by their username.",
+                "consumes": [
+                    "application/json"
+                ],
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "users"
+                ],
+                "summary": "Get user profile",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.UserResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/users/{username}/follow": {
             "post": {
                 "security": [

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -350,6 +350,39 @@ paths:
       summary: Update post
       tags:
       - posts
+  /users/{username}:
+    get:
+      consumes:
+      - application/json
+      description: Get the profile of a user by their username.
+      parameters:
+      - description: Username
+        in: path
+        name: username
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/github_com_billykore_project-one_internal_api_dto.UserResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse'
+      summary: Get user profile
+      tags:
+      - users
   /users/{username}/follow:
     delete:
       consumes:

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -443,6 +443,10 @@ paths:
           description: Unauthorized
           schema:
             $ref: '#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse'
         "500":
           description: Internal Server Error
           schema:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -91,6 +91,7 @@ func main() {
 	e.GET("/users/me", userHdl.Me, middleware.Authorize(tokenSvc))
 	e.GET("/users/me/following", userHdl.GetFollowing, middleware.Authorize(tokenSvc))
 	e.GET("/users/me/followers", userHdl.GetFollowers, middleware.Authorize(tokenSvc))
+	e.GET("/users/:username", userHdl.GetProfile)
 	e.POST("/users/:username/follow", userHdl.HandleFollow, middleware.Authorize(tokenSvc))
 	e.DELETE("/users/:username/follow", userHdl.HandleUnfollow, middleware.Authorize(tokenSvc))
 	e.POST("/posts", postHdl.CreatePost, middleware.Authorize(tokenSvc))

--- a/docs/superpowers/plans/2026-05-15-get-user-by-username.md
+++ b/docs/superpowers/plans/2026-05-15-get-user-by-username.md
@@ -1,0 +1,221 @@
+# GET /users/:username Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create a public API endpoint `GET /users/:username` to retrieve user profile information.
+
+**Architecture:** Following Clean Architecture, we'll extend the `UserUseCase` port, implement the logic in `userUseCase`, add a handler method in `UserHandler`, and register the route in `cmd/main.go`.
+
+**Tech Stack:** Go, Echo, GORM, Testify, GoMock.
+
+---
+
+### Task 1: Update UserUseCase Port
+
+**Files:**
+- Modify: `internal/core/ports/user.go`
+
+- [ ] **Step 1: Add GetUserProfile to UserUseCase interface**
+
+```go
+type UserUseCase interface {
+	GetCurrentUser(ctx context.Context, username string) (*domain.User, error)
+	Register(ctx context.Context, user *domain.User) error
+	// Add this:
+	GetUserProfile(ctx context.Context, username string) (*domain.User, error)
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add internal/core/ports/user.go
+git commit -m "port: add GetUserProfile to UserUseCase"
+```
+
+---
+
+### Task 2: Implement UserUseCase.GetUserProfile
+
+**Files:**
+- Modify: `internal/core/usecase/user_usecase.go`
+- Test: `internal/core/usecase/user_usecase_test.go`
+
+- [ ] **Step 1: Write failing test in user_usecase_test.go**
+
+```go
+func TestUserUseCase_GetUserProfile(t *testing.T) {
+    ctrl := gomock.NewController(t)
+    defer ctrl.Finish()
+
+    mockUserRepo := mocks.NewMockUserRepository(ctrl)
+    mockTokenRepo := mocks.NewMockTokenRepository(ctrl)
+    mockHasher := mocks.NewMockHasher(ctrl)
+    
+    uc := NewUserUseCase(mockUserRepo, mockTokenRepo, mockHasher)
+    ctx := context.Background()
+    username := "testuser"
+
+    t.Run("success", func(t *testing.T) {
+        expectedUser := &domain.User{Username: username}
+        mockUserRepo.EXPECT().GetUserByUsername(ctx, username).Return(expectedUser, nil)
+
+        user, err := uc.GetUserProfile(ctx, username)
+        assert.NoError(t, err)
+        assert.Equal(t, expectedUser, user)
+    })
+
+    t.Run("not found", func(t *testing.T) {
+        mockUserRepo.EXPECT().GetUserByUsername(ctx, username).Return(nil, domain.ErrUserNotFound)
+
+        user, err := uc.GetUserProfile(ctx, username)
+        assert.ErrorIs(t, err, domain.ErrUserNotFound)
+        assert.Nil(t, user)
+    })
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `go test -v internal/core/usecase/user_usecase_test.go`
+Expected: Compilation error (GetUserProfile not implemented)
+
+- [ ] **Step 3: Implement GetUserProfile in user_usecase.go**
+
+```go
+func (s *userUseCase) GetUserProfile(ctx context.Context, username string) (*domain.User, error) {
+	user, err := s.userRepo.GetUserByUsername(ctx, username)
+	if err != nil {
+		return nil, fmt.Errorf("get user by username: %w", err)
+	}
+	return user, nil
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `go test -v ./internal/core/usecase/...`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/core/usecase/user_usecase.go internal/core/usecase/user_usecase_test.go
+git commit -m "usecase: implement GetUserProfile"
+```
+
+---
+
+### Task 3: Implement UserHandler.GetProfile
+
+**Files:**
+- Modify: `internal/api/handler/user_handler.go`
+- Test: `internal/api/handler/user_handler_test.go` (Create if not exists)
+
+- [ ] **Step 1: Write failing test for GetProfile**
+
+```go
+func TestUserHandler_GetProfile(t *testing.T) {
+    // Setup Echo and Mocks
+    e := echo.New()
+    mockUC := mocks.NewMockUserUseCase(ctrl)
+    h := NewUserHandler(mockUC, ...)
+
+    t.Run("success", func(t *testing.T) {
+        username := "johndoe"
+        req := httptest.NewRequest(http.MethodGet, "/users/"+username, nil)
+        rec := httptest.NewRecorder()
+        c := e.NewContext(req, rec)
+        c.SetParamNames("username")
+        c.SetParamValues(username)
+
+        mockUC.EXPECT().GetUserProfile(gomock.Any(), username).Return(&domain.User{
+            Username: username,
+            Email: "johndoe@gmail.com",
+            FirstName: "John",
+            LastName: "Doe",
+        }, nil)
+
+        if assert.NoError(t, h.GetProfile(c)) {
+            assert.Equal(t, http.StatusOK, rec.Code)
+            // Verify JSON body
+        }
+    })
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Expected: Compilation error (GetProfile not defined)
+
+- [ ] **Step 3: Implement GetProfile in user_handler.go**
+
+```go
+func (h *UserHandler) GetProfile(c echo.Context) error {
+	username := c.Param("username")
+	if username == "" {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: "Invalid username"})
+	}
+
+	user, err := h.userUseCase.GetUserProfile(c.Request().Context(), username)
+	if err != nil {
+		if errors.Is(err, domain.ErrUserNotFound) {
+			return c.JSON(http.StatusNotFound, dto.ErrorResponse{Error: fmt.Sprintf("User %s not found", username)})
+		}
+		h.log.Error(c.Request().Context(), "failed to get user profile", "username", username, "error", err)
+		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Error: "Something went wrong"})
+	}
+
+	res := dto.UserResponse{
+		Username: user.Username,
+		Email:    user.Email,
+		Name:     user.FirstName + " " + user.LastName,
+	}
+
+	return c.JSON(http.StatusOK, res)
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/api/handler/user_handler.go
+git commit -m "api: implement GetProfile handler"
+```
+
+---
+
+### Task 4: Register Route
+
+**Files:**
+- Modify: `cmd/main.go` (or wherever routes are registered)
+
+- [ ] **Step 1: Find route registration and add the new endpoint**
+
+Search for `v1 := e.Group("/api/v1")` or similar.
+Add: `e.GET("/users/:username", userHandler.GetProfile)`
+
+- [ ] **Step 2: Verify with manual curl or integration test**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add cmd/main.go
+git commit -m "api: register GET /users/:username route"
+```
+
+---
+
+### Task 5: Update Swagger Docs
+
+- [ ] **Step 1: Add Swagger annotations to GetProfile**
+- [ ] **Step 2: Run `make docs`**
+- [ ] **Step 3: Commit**
+
+```bash
+make docs
+git add internal/api/handler/user_handler.go api/swagger/
+git commit -m "docs: update swagger for GetProfile"
+```

--- a/docs/superpowers/specs/2026-05-15-get-user-by-username-design.md
+++ b/docs/superpowers/specs/2026-05-15-get-user-by-username-design.md
@@ -1,0 +1,65 @@
+# Design Document: GET /users/:username API
+
+**Date:** 2026-05-15
+**Status:** Approved
+**Topic:** Create an API for getting user by username.
+
+## 1. Overview
+The goal is to provide a public API endpoint that allows clients to retrieve basic user profile information (username, email, and full name) using a username.
+
+## 2. Architecture
+The implementation follows Clean Architecture principles:
+- **API Layer**: Echo handler to manage HTTP request/response.
+- **UseCase Layer**: Business logic to orchestrate the retrieval.
+- **Ports Layer**: Interface definition for the UseCase.
+- **Domain Layer**: User entity.
+- **Repository Layer**: Data access (already implemented).
+
+## 3. Detailed Components
+
+### 3.1 Ports (`internal/core/ports/user.go`)
+Extend the `UserUseCase` interface:
+```go
+type UserUseCase interface {
+    // ... existing methods
+    GetUserProfile(ctx context.Context, username string) (*domain.User, error)
+}
+```
+
+### 3.2 UseCase (`internal/core/usecase/user_usecase.go`)
+Implement `GetUserProfile`:
+```go
+func (s *userUseCase) GetUserProfile(ctx context.Context, username string) (*domain.User, error) {
+    user, err := s.userRepo.GetUserByUsername(ctx, username)
+    if err != nil {
+        return nil, fmt.Errorf("get user by username: %w", err)
+    }
+    return user, nil
+}
+```
+
+### 3.3 Handler (`internal/api/handler/user_handler.go`)
+Add `GetProfile` method:
+- **Endpoint**: `GET /users/:username`
+- **Logic**:
+  1. Extract `username` from path param.
+  2. Call `h.userUseCase.GetUserProfile`.
+  3. Map `domain.User` to `dto.UserResponse`.
+- **Response Mapping**:
+  - `Username` -> `user.Username`
+  - `Email` -> `user.Email`
+  - `Name` -> `user.FirstName + " " + user.LastName`
+
+### 3.4 Routing
+The route will be registered in the public group (no JWT middleware required):
+```go
+e.GET("/users/:username", userHandler.GetProfile)
+```
+
+## 4. Error Handling
+- **404 Not Found**: Returned when `userRepo.GetUserByUsername` returns `domain.ErrUserNotFound`. Message: `"User {username} not found"`.
+- **500 Internal Server Error**: Returned for any other database or unexpected error. Message: `"Something went wrong"`.
+
+## 5. Testing Strategy
+- **Unit Test (UseCase)**: Mock `UserRepository` to test successful retrieval and "not found" scenario.
+- **Unit Test (Handler)**: Mock `UserUseCase` to verify status codes (200, 404, 500) and correct DTO mapping.

--- a/docs/superpowers/tasks.md
+++ b/docs/superpowers/tasks.md
@@ -1,0 +1,7 @@
+# Implementation Tasks
+
+- [x] Task 1: Update UserUseCase Port
+- [x] Task 2: Implement UserUseCase.GetUserProfile
+- [x] Task 3: Implement UserHandler.GetProfile
+- [x] Task 4: Register Route
+- [x] Task 5: Update Swagger Docs

--- a/internal/api/handler/user_handler.go
+++ b/internal/api/handler/user_handler.go
@@ -65,16 +65,10 @@ func (h *UserHandler) Me(c echo.Context) error {
 			return c.JSON(http.StatusUnauthorized, dto.ErrorResponse{Error: "Unauthorized"})
 		}
 		h.log.Error(c.Request().Context(), "failed to get current user", "username", username, "error", err)
-		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Error: "Internal Server Error"})
+		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Error: "Internal server error"})
 	}
 
-	res := dto.UserResponse{
-		Username: user.Username,
-		Email:    user.Email,
-		Name:     user.FirstName + " " + user.LastName,
-	}
-
-	return c.JSON(http.StatusOK, res)
+	return c.JSON(http.StatusOK, toUserResponse(user))
 }
 
 // GetProfile handles the GET /users/:username endpoint.
@@ -102,16 +96,10 @@ func (h *UserHandler) GetProfile(c echo.Context) error {
 			return c.JSON(http.StatusNotFound, dto.ErrorResponse{Error: fmt.Sprintf("User %s not found", username)})
 		}
 		h.log.Error(c.Request().Context(), "failed to get user profile", "username", username, "error", err)
-		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Error: "Something went wrong"})
+		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Error: "Internal server error"})
 	}
 
-	res := dto.UserResponse{
-		Username: user.Username,
-		Email:    user.Email,
-		Name:     user.FirstName + " " + user.LastName,
-	}
-
-	return c.JSON(http.StatusOK, res)
+	return c.JSON(http.StatusOK, toUserResponse(user))
 }
 
 // HandleLogin handles the POST /users/login endpoint.
@@ -430,5 +418,13 @@ func toFollowerResponse(f domain.Follower) dto.FollowerResponse {
 		Name:       f.FirstName + " " + f.LastName,
 		FollowedAt: f.FollowedAt.Format(time.RFC3339),
 		IsMutual:   f.IsMutual,
+	}
+}
+
+func toUserResponse(user *domain.User) dto.UserResponse {
+	return dto.UserResponse{
+		Username: user.Username,
+		Email:    user.Email,
+		Name:     user.FirstName + " " + user.LastName,
 	}
 }

--- a/internal/api/handler/user_handler.go
+++ b/internal/api/handler/user_handler.go
@@ -2,6 +2,7 @@ package handler
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -65,6 +66,43 @@ func (h *UserHandler) Me(c echo.Context) error {
 		}
 		h.log.Error(c.Request().Context(), "failed to get current user", "username", username, "error", err)
 		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Error: "Internal Server Error"})
+	}
+
+	res := dto.UserResponse{
+		Username: user.Username,
+		Email:    user.Email,
+		Name:     user.FirstName + " " + user.LastName,
+	}
+
+	return c.JSON(http.StatusOK, res)
+}
+
+// GetProfile handles the GET /users/:username endpoint.
+//
+//	@Summary		Get user profile
+//	@Description	Get the profile of a user by their username.
+//	@Tags			users
+//	@Accept			json
+//	@Produce		json
+//	@Param			username	path		string	true	"Username"
+//	@Success		200			{object}	dto.UserResponse
+//	@Failure		400			{object}	dto.ErrorResponse
+//	@Failure		404			{object}	dto.ErrorResponse
+//	@Failure		500			{object}	dto.ErrorResponse
+//	@Router			/users/{username} [get]
+func (h *UserHandler) GetProfile(c echo.Context) error {
+	username := c.Param("username")
+	if username == "" {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: "Invalid username"})
+	}
+
+	user, err := h.userUseCase.GetUserProfile(c.Request().Context(), username)
+	if err != nil {
+		if errors.Is(err, domain.ErrUserNotFound) {
+			return c.JSON(http.StatusNotFound, dto.ErrorResponse{Error: fmt.Sprintf("User %s not found", username)})
+		}
+		h.log.Error(c.Request().Context(), "failed to get user profile", "username", username, "error", err)
+		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Error: "Something went wrong"})
 	}
 
 	res := dto.UserResponse{

--- a/internal/api/handler/user_handler.go
+++ b/internal/api/handler/user_handler.go
@@ -235,6 +235,7 @@ func (h *UserHandler) HandleRegister(c echo.Context) error {
 //	@Success		200			{object}	dto.FollowResponse
 //	@Failure		400			{object}	dto.ErrorResponse
 //	@Failure		401			{object}	dto.ErrorResponse
+//	@Failure		404			{object}	dto.ErrorResponse
 //	@Failure		500			{object}	dto.ErrorResponse
 //	@Security		BearerAuth
 //	@Router			/users/{username}/follow [post]

--- a/internal/api/handler/user_handler_test.go
+++ b/internal/api/handler/user_handler_test.go
@@ -1,0 +1,120 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/billykore/project-one/internal/api/dto"
+	"github.com/billykore/project-one/internal/core/domain"
+	"github.com/billykore/project-one/internal/core/usecase/mocks"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.uber.org/mock/gomock"
+)
+
+func TestUserHandler_GetProfile(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockUserUC := mocks.NewMockUserUseCase(ctrl)
+	mockLoginUC := mocks.NewMockLoginUseCase(ctrl)
+	mockFollowUC := mocks.NewMockFollowUseCase(ctrl)
+	mockValidator := mocks.NewMockValidator(ctrl)
+	mockLogger := mocks.NewMockLogger(ctrl)
+
+	h := NewUserHandler(mockUserUC, mockLoginUC, mockFollowUC, mockValidator, mockLogger)
+	e := echo.New()
+
+	t.Run("success", func(t *testing.T) {
+		username := "testuser"
+		user := &domain.User{
+			Username:  username,
+			Email:     "test@example.com",
+			FirstName: "Test",
+			LastName:  "User",
+		}
+
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath("/users/:username")
+		c.SetParamNames("username")
+		c.SetParamValues(username)
+
+		mockUserUC.EXPECT().GetUserProfile(gomock.Any(), username).Return(user, nil)
+
+		if assert.NoError(t, h.GetProfile(c)) {
+			assert.Equal(t, http.StatusOK, rec.Code)
+			var res dto.UserResponse
+			err := json.Unmarshal(rec.Body.Bytes(), &res)
+			require.NoError(t, err)
+			assert.Equal(t, user.Username, res.Username)
+			assert.Equal(t, user.Email, res.Email)
+			assert.Equal(t, user.FirstName+" "+user.LastName, res.Name)
+		}
+	})
+
+	t.Run("user not found", func(t *testing.T) {
+		username := "notfound"
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath("/users/:username")
+		c.SetParamNames("username")
+		c.SetParamValues(username)
+
+		mockUserUC.EXPECT().GetUserProfile(gomock.Any(), username).Return(nil, domain.ErrUserNotFound)
+
+		if assert.NoError(t, h.GetProfile(c)) {
+			assert.Equal(t, http.StatusNotFound, rec.Code)
+			var res dto.ErrorResponse
+			err := json.Unmarshal(rec.Body.Bytes(), &res)
+			require.NoError(t, err)
+			assert.Equal(t, fmt.Sprintf("User %s not found", username), res.Error)
+		}
+	})
+
+	t.Run("invalid username", func(t *testing.T) {
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath("/users/:username")
+		c.SetParamNames("username")
+		c.SetParamValues("")
+
+		if assert.NoError(t, h.GetProfile(c)) {
+			assert.Equal(t, http.StatusBadRequest, rec.Code)
+			var res dto.ErrorResponse
+			err := json.Unmarshal(rec.Body.Bytes(), &res)
+			require.NoError(t, err)
+			assert.Equal(t, "Invalid username", res.Error)
+		}
+	})
+
+	t.Run("internal server error", func(t *testing.T) {
+		username := "testuser"
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath("/users/:username")
+		c.SetParamNames("username")
+		c.SetParamValues(username)
+
+		errSome := errors.New("something went wrong")
+		mockUserUC.EXPECT().GetUserProfile(gomock.Any(), username).Return(nil, errSome)
+		mockLogger.EXPECT().Error(gomock.Any(), "failed to get user profile", "username", username, "error", errSome)
+
+		if assert.NoError(t, h.GetProfile(c)) {
+			assert.Equal(t, http.StatusInternalServerError, rec.Code)
+			var res dto.ErrorResponse
+			err := json.Unmarshal(rec.Body.Bytes(), &res)
+			require.NoError(t, err)
+			assert.Equal(t, "Something went wrong", res.Error)
+		}
+	})
+}

--- a/internal/api/handler/user_handler_test.go
+++ b/internal/api/handler/user_handler_test.go
@@ -114,7 +114,7 @@ func TestUserHandler_GetProfile(t *testing.T) {
 			var res dto.ErrorResponse
 			err := json.Unmarshal(rec.Body.Bytes(), &res)
 			require.NoError(t, err)
-			assert.Equal(t, "Something went wrong", res.Error)
+			assert.Equal(t, "Internal server error", res.Error)
 		}
 	})
 }

--- a/internal/core/ports/user.go
+++ b/internal/core/ports/user.go
@@ -24,4 +24,6 @@ type UserUseCase interface {
 	GetCurrentUser(ctx context.Context, username string) (*domain.User, error)
 	// Register creates a new user account.
 	Register(ctx context.Context, user *domain.User) error
+	// GetUserProfile retrieves the profile of the user with the given username.
+	GetUserProfile(ctx context.Context, username string) (*domain.User, error)
 }

--- a/internal/core/usecase/mocks/mock_user.go
+++ b/internal/core/usecase/mocks/mock_user.go
@@ -139,6 +139,21 @@ func (mr *MockUserUseCaseMockRecorder) GetCurrentUser(ctx, username any) *gomock
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCurrentUser", reflect.TypeOf((*MockUserUseCase)(nil).GetCurrentUser), ctx, username)
 }
 
+// GetUserProfile mocks base method.
+func (m *MockUserUseCase) GetUserProfile(ctx context.Context, username string) (*domain.User, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetUserProfile", ctx, username)
+	ret0, _ := ret[0].(*domain.User)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetUserProfile indicates an expected call of GetUserProfile.
+func (mr *MockUserUseCaseMockRecorder) GetUserProfile(ctx, username any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserProfile", reflect.TypeOf((*MockUserUseCase)(nil).GetUserProfile), ctx, username)
+}
+
 // Register mocks base method.
 func (m *MockUserUseCase) Register(ctx context.Context, user *domain.User) error {
 	m.ctrl.T.Helper()

--- a/internal/core/usecase/user_usecase.go
+++ b/internal/core/usecase/user_usecase.go
@@ -41,6 +41,14 @@ func (s *userUseCase) GetCurrentUser(ctx context.Context, username string) (*dom
 	return user, nil
 }
 
+func (s *userUseCase) GetUserProfile(ctx context.Context, username string) (*domain.User, error) {
+	user, err := s.userRepo.GetUserByUsername(ctx, username)
+	if err != nil {
+		return nil, fmt.Errorf("get user by username: %w", err)
+	}
+	return user, nil
+}
+
 func (s *userUseCase) Register(ctx context.Context, user *domain.User) error {
 	existingUser, err := s.userRepo.GetUserByEmail(ctx, user.Email)
 	if err == nil && existingUser != nil {

--- a/internal/core/usecase/user_usecase_test.go
+++ b/internal/core/usecase/user_usecase_test.go
@@ -7,8 +7,39 @@ import (
 
 	"github.com/billykore/project-one/internal/core/domain"
 	"github.com/billykore/project-one/internal/core/usecase/mocks"
+	"github.com/stretchr/testify/assert"
 	"go.uber.org/mock/gomock"
 )
+
+func TestUserUseCase_GetUserProfile(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRepo := mocks.NewMockUserRepository(ctrl)
+	mockTokenRepo := mocks.NewMockTokenRepository(ctrl)
+	mockHasher := mocks.NewMockHasher(ctrl)
+	svc := NewUserUseCase(mockRepo, mockTokenRepo, mockHasher)
+
+	ctx := context.Background()
+	username := "testuser"
+
+	t.Run("success", func(t *testing.T) {
+		expectedUser := &domain.User{Username: username}
+		mockRepo.EXPECT().GetUserByUsername(ctx, username).Return(expectedUser, nil)
+
+		user, err := svc.GetUserProfile(ctx, username)
+		assert.NoError(t, err)
+		assert.Equal(t, expectedUser, user)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		mockRepo.EXPECT().GetUserByUsername(ctx, username).Return(nil, domain.ErrUserNotFound)
+
+		user, err := svc.GetUserProfile(ctx, username)
+		assert.ErrorIs(t, err, domain.ErrUserNotFound)
+		assert.Nil(t, user)
+	})
+}
 
 func TestUserUseCase_GetCurrentUser(t *testing.T) {
 	ctrl := gomock.NewController(t)

--- a/internal/core/usecase/user_usecase_test.go
+++ b/internal/core/usecase/user_usecase_test.go
@@ -2,7 +2,6 @@ package usecase
 
 import (
 	"context"
-	"errors"
 	"testing"
 
 	"github.com/billykore/project-one/internal/core/domain"
@@ -24,7 +23,13 @@ func TestUserUseCase_GetUserProfile(t *testing.T) {
 	username := "testuser"
 
 	t.Run("success", func(t *testing.T) {
-		expectedUser := &domain.User{Username: username}
+		expectedUser := &domain.User{
+			ID:        1,
+			FirstName: "Test",
+			LastName:  "User",
+			Username:  username,
+			Email:     "test@example.com",
+		}
 		mockRepo.EXPECT().GetUserByUsername(ctx, username).Return(expectedUser, nil)
 
 		user, err := svc.GetUserProfile(ctx, username)
@@ -59,12 +64,8 @@ func TestUserUseCase_GetCurrentUser(t *testing.T) {
 		mockRepo.EXPECT().GetUserByUsername(ctx, username).Return(expectedUser, nil)
 		user, err := svc.GetCurrentUser(ctx, username)
 
-		if err != nil {
-			t.Errorf("GetCurrentUser() unexpected error = %v", err)
-		}
-		if user != expectedUser {
-			t.Errorf("GetCurrentUser() user = %v, want %v", user, expectedUser)
-		}
+		assert.NoError(t, err)
+		assert.Equal(t, expectedUser, user)
 	})
 
 	t.Run("user not found", func(t *testing.T) {
@@ -74,12 +75,8 @@ func TestUserUseCase_GetCurrentUser(t *testing.T) {
 
 		user, err := svc.GetCurrentUser(ctx, username)
 
-		if !errors.Is(err, domain.ErrUserNotFound) {
-			t.Errorf("GetCurrentUser() error = %v, want %v", err, domain.ErrUserNotFound)
-		}
-		if user != nil {
-			t.Errorf("GetCurrentUser() user = %v, want nil", user)
-		}
+		assert.ErrorIs(t, err, domain.ErrUserNotFound)
+		assert.Nil(t, user)
 	})
 }
 
@@ -107,21 +104,15 @@ func TestUserUseCase_Register(t *testing.T) {
 		mockRepo.EXPECT().GetUserByUsername(ctx, user.Username).Return(nil, domain.ErrUserNotFound)
 		mockHasher.EXPECT().Hash(ctx, user.Password).Return("hashed_password", nil)
 		mockRepo.EXPECT().CreateUser(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, u *domain.User) error {
-			if u.Password != "hashed_password" {
-				t.Errorf("expected hashed password, got %s", u.Password)
-			}
+			assert.Equal(t, "hashed_password", u.Password)
 			u.ID = 1
 			return nil
 		})
 
 		err := svc.Register(ctx, user)
 
-		if err != nil {
-			t.Errorf("Register() unexpected error = %v", err)
-		}
-		if user.ID != 1 {
-			t.Errorf("expected user ID 1, got %d", user.ID)
-		}
+		assert.NoError(t, err)
+		assert.Equal(t, 1, user.ID)
 	})
 
 	t.Run("email already registered", func(t *testing.T) {
@@ -133,9 +124,7 @@ func TestUserUseCase_Register(t *testing.T) {
 
 		err := svc.Register(ctx, user)
 
-		if !errors.Is(err, domain.ErrEmailAlreadyRegistered) {
-			t.Errorf("Register() error = %v, want %v", err, domain.ErrEmailAlreadyRegistered)
-		}
+		assert.ErrorIs(t, err, domain.ErrEmailAlreadyRegistered)
 	})
 
 	t.Run("username already taken", func(t *testing.T) {
@@ -149,9 +138,7 @@ func TestUserUseCase_Register(t *testing.T) {
 
 		err := svc.Register(ctx, user)
 
-		if !errors.Is(err, domain.ErrUsernameAlreadyTaken) {
-			t.Errorf("Register() error = %v, want %v", err, domain.ErrUsernameAlreadyTaken)
-		}
+		assert.ErrorIs(t, err, domain.ErrUsernameAlreadyTaken)
 	})
 
 	t.Run("validation failure", func(t *testing.T) {
@@ -168,8 +155,6 @@ func TestUserUseCase_Register(t *testing.T) {
 
 		err := svc.Register(ctx, user)
 
-		if !errors.Is(err, domain.ErrValidationFailed) {
-			t.Errorf("Register() error = %v, want %v", err, domain.ErrValidationFailed)
-		}
+		assert.ErrorIs(t, err, domain.ErrValidationFailed)
 	})
 }


### PR DESCRIPTION
## Summary
- Added `GetUserProfile` to `UserUseCase` port and implementation.
- Implemented `GetProfile` handler in `UserHandler` with error handling for 400, 404, and 500 status codes.
- Registered `GET /users/:username` as a public route in `cmd/main.go`.
- Refactored user response mapping into a helper function in `UserHandler`.
- Updated Swagger documentation.

## Test Plan
- [x] Unit tests for `UserUseCase` (`internal/core/usecase/user_usecase_test.go`) are passing.
- [x] Unit tests for `UserHandler` (`internal/api/handler/user_handler_test.go`) are passing.
- [x] Documentation regenerated and verified via `make docs`.
- [x] Linting passed with `golangci-lint`.

Closes #58