### PR TITLE
feat: implement get user posts by username

### DIFF
--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -778,6 +778,62 @@ const docTemplate = `{
                     }
                 }
             }
+        },
+        "/users/{username}/posts": {
+            "get": {
+                "description": "Retrieve all posts for a specific user by username.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "posts"
+                ],
+                "summary": "Get user posts by username",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Limit",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.PostResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -913,6 +969,9 @@ const docTemplate = `{
         "github_com_billykore_project-one_internal_api_dto.PostResponse": {
             "type": "object",
             "properties": {
+                "author": {
+                    "type": "string"
+                },
                 "content": {
                     "type": "string"
                 },

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -772,6 +772,62 @@
                     }
                 }
             }
+        },
+        "/users/{username}/posts": {
+            "get": {
+                "description": "Retrieve all posts for a specific user by username.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "posts"
+                ],
+                "summary": "Get user posts by username",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "Username",
+                        "name": "username",
+                        "in": "path",
+                        "required": true
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Limit",
+                        "name": "limit",
+                        "in": "query"
+                    },
+                    {
+                        "type": "integer",
+                        "description": "Offset",
+                        "name": "offset",
+                        "in": "query"
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.PostResponse"
+                            }
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse"
+                        }
+                    }
+                }
+            }
         }
     },
     "definitions": {
@@ -907,6 +963,9 @@
         "github_com_billykore_project-one_internal_api_dto.PostResponse": {
             "type": "object",
             "properties": {
+                "author": {
+                    "type": "string"
+                },
                 "content": {
                     "type": "string"
                 },

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -86,6 +86,8 @@ definitions:
     type: object
   github_com_billykore_project-one_internal_api_dto.PostResponse:
     properties:
+      author:
+        type: string
       content:
         type: string
       created_at:
@@ -456,6 +458,43 @@ paths:
       summary: Follow a user
       tags:
       - users
+  /users/{username}/posts:
+    get:
+      description: Retrieve all posts for a specific user by username.
+      parameters:
+      - description: Username
+        in: path
+        name: username
+        required: true
+        type: string
+      - description: Limit
+        in: query
+        name: limit
+        type: integer
+      - description: Offset
+        in: query
+        name: offset
+        type: integer
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            items:
+              $ref: '#/definitions/github_com_billykore_project-one_internal_api_dto.PostResponse'
+            type: array
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/github_com_billykore_project-one_internal_api_dto.ErrorResponse'
+      summary: Get user posts by username
+      tags:
+      - posts
   /users/login:
     post:
       consumes:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,7 +68,7 @@ func main() {
 	// 4. Initialize UseCase
 	loginUc := usecase.NewLoginUseCase(userRepo, tokenSvc, userTokenRepo, hasher, lgr)
 	userUc := usecase.NewUserUseCase(userRepo, userTokenRepo, hasher)
-	postUc := usecase.NewPostUseCase(postRepo, userRepo, lgr)
+	postUc := usecase.NewPostUseCase(postRepo, lgr)
 	followUc := usecase.NewFollowUseCase(followRepo, userRepo)
 
 	// 5. Initialize Handler

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -68,7 +68,7 @@ func main() {
 	// 4. Initialize UseCase
 	loginUc := usecase.NewLoginUseCase(userRepo, tokenSvc, userTokenRepo, hasher, lgr)
 	userUc := usecase.NewUserUseCase(userRepo, userTokenRepo, hasher)
-	postUc := usecase.NewPostUseCase(postRepo, lgr)
+	postUc := usecase.NewPostUseCase(postRepo, userRepo, lgr)
 	followUc := usecase.NewFollowUseCase(followRepo, userRepo)
 
 	// 5. Initialize Handler
@@ -94,6 +94,7 @@ func main() {
 	e.GET("/users/:username", userHdl.GetProfile)
 	e.POST("/users/:username/follow", userHdl.HandleFollow, middleware.Authorize(tokenSvc))
 	e.DELETE("/users/:username/follow", userHdl.HandleUnfollow, middleware.Authorize(tokenSvc))
+	e.GET("/users/:username/posts", postHdl.GetUserPosts)
 	e.POST("/posts", postHdl.CreatePost, middleware.Authorize(tokenSvc))
 	e.GET("/posts", postHdl.GetPosts, middleware.Authorize(tokenSvc))
 	e.GET("/posts/:id", postHdl.GetPostByID, middleware.Authorize(tokenSvc))

--- a/internal/adapters/repository/post_repository.go
+++ b/internal/adapters/repository/post_repository.go
@@ -12,10 +12,10 @@ import (
 
 type postModel struct {
 	gorm.Model
-	UserID  uint           `gorm:"notNull"`
-	Title   string         `gorm:"size:255;notNull"`
-	Content string         `gorm:"type:text;notNull"`
-	Tags    pq.StringArray `gorm:"type:text[]"`
+	Username string         `gorm:"size:255;notNull"`
+	Title    string         `gorm:"size:255;notNull"`
+	Content  string         `gorm:"type:text;notNull"`
+	Tags     pq.StringArray `gorm:"type:text[]"`
 }
 
 func (m *postModel) TableName() string {
@@ -23,7 +23,7 @@ func (m *postModel) TableName() string {
 }
 
 func (m *postModel) fromDomain(p *domain.Post) {
-	m.UserID = uint(p.UserID)
+	m.Username = p.Username
 	m.Title = p.Title
 	m.Content = p.Content
 	m.Tags = pq.StringArray(p.Tags)
@@ -32,7 +32,7 @@ func (m *postModel) fromDomain(p *domain.Post) {
 func (m *postModel) toDomain() *domain.Post {
 	return &domain.Post{
 		ID:        int(m.ID),
-		UserID:    int(m.UserID),
+		Username:  m.Username,
 		Title:     m.Title,
 		Content:   m.Content,
 		Tags:      []string(m.Tags),
@@ -63,9 +63,12 @@ func (r *postRepository) Create(ctx context.Context, post *domain.Post) error {
 	return nil
 }
 
-func (r *postRepository) GetByID(ctx context.Context, id int) (*domain.Post, error) {
+func (r *postRepository) GetByID(ctx context.Context, username string, id int) (*domain.Post, error) {
 	var m postModel
-	if err := r.db.WithContext(ctx).First(&m, id).Error; err != nil {
+	err := r.db.WithContext(ctx).
+		Where("username = ? AND id = ?", username, id).
+		First(&m).Error
+	if err != nil {
 		if errors.Is(err, gorm.ErrRecordNotFound) {
 			return nil, domain.ErrPostNotFound
 		}
@@ -74,9 +77,9 @@ func (r *postRepository) GetByID(ctx context.Context, id int) (*domain.Post, err
 	return m.toDomain(), nil
 }
 
-func (r *postRepository) GetPostsByUserID(ctx context.Context, userID, limit, offset int) ([]*domain.Post, error) {
+func (r *postRepository) GetUserPosts(ctx context.Context, username string, limit, offset int) ([]*domain.Post, error) {
 	var models []postModel
-	query := r.db.WithContext(ctx).Where("user_id = ?", userID)
+	query := r.db.WithContext(ctx).Where("username = ?", username)
 
 	if limit > 0 {
 		query = query.Limit(limit)
@@ -96,19 +99,22 @@ func (r *postRepository) GetPostsByUserID(ctx context.Context, userID, limit, of
 	return posts, nil
 }
 
-func (r *postRepository) Update(ctx context.Context, post *domain.Post) error {
+func (r *postRepository) Update(ctx context.Context, username string, post *domain.Post) error {
 	var m postModel
 	m.ID = uint(post.ID)
 	m.fromDomain(post)
-	if err := r.db.WithContext(ctx).Model(&m).Select("Title", "Content", "Tags").Updates(m).Error; err != nil {
+	if err := r.db.WithContext(ctx).Model(&m).
+		Select("Title", "Content", "Tags").
+		Where("username = ? AND id = ?", username, post.ID).
+		Updates(m).Error; err != nil {
 		return err
 	}
 	post.UpdatedAt = m.UpdatedAt
 	return nil
 }
 
-func (r *postRepository) Delete(ctx context.Context, id int) error {
-	if err := r.db.WithContext(ctx).Delete(&postModel{}, id).Error; err != nil {
+func (r *postRepository) Delete(ctx context.Context, username string, id int) error {
+	if err := r.db.WithContext(ctx).Where("username = ? AND id = ?", username, id).Delete(&postModel{}).Error; err != nil {
 		return err
 	}
 	return nil

--- a/internal/api/dto/post_dto.go
+++ b/internal/api/dto/post_dto.go
@@ -19,6 +19,7 @@ type PostResponse struct {
 	Title     string    `json:"title,omitempty"`
 	Content   string    `json:"content,omitempty"`
 	Tags      []string  `json:"tags,omitempty"`
+	Author    string    `json:"author,omitempty"`
 	CreatedAt time.Time `json:"created_at"`
 	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/internal/api/handler/post_handler.go
+++ b/internal/api/handler/post_handler.go
@@ -45,7 +45,7 @@ func NewPostHandler(postUseCase ports.PostUseCase, validator ports.Validator) *P
 //	@Security		BearerAuth
 //	@Router			/posts [post]
 func (h *PostHandler) CreatePost(c echo.Context) error {
-	userID, ok := c.Get("userID").(int)
+	username, ok := c.Get("username").(string)
 	if !ok {
 		return c.JSON(http.StatusUnauthorized, dto.ErrorResponse{Error: "Unauthorized"})
 	}
@@ -72,7 +72,7 @@ func (h *PostHandler) CreatePost(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: "Validation failed"})
 	}
 
-	post, err := h.postUseCase.CreatePost(c.Request().Context(), userID, req.Title, req.Content, req.Tags)
+	post, err := h.postUseCase.CreatePost(c.Request().Context(), username, req.Title, req.Content, req.Tags)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Error: "Something went wrong"})
 	}
@@ -98,7 +98,7 @@ func (h *PostHandler) CreatePost(c echo.Context) error {
 //	@Failure		500	{object}	dto.ErrorResponse
 //	@Router			/posts/{id} [get]
 func (h *PostHandler) GetPostByID(c echo.Context) error {
-	userID, ok := c.Get("userID").(int)
+	username, ok := c.Get("username").(string)
 	if !ok {
 		return c.JSON(http.StatusUnauthorized, dto.ErrorResponse{Error: "Unauthorized"})
 	}
@@ -109,7 +109,7 @@ func (h *PostHandler) GetPostByID(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: "Post ID must be a number"})
 	}
 
-	post, err := h.postUseCase.GetPostByID(c.Request().Context(), userID, id)
+	post, err := h.postUseCase.GetPostByID(c.Request().Context(), username, id)
 	if err != nil {
 		if errors.Is(err, domain.ErrPostNotFound) {
 			return c.JSON(http.StatusNotFound, dto.ErrorResponse{Error: "Post not found"})
@@ -147,7 +147,7 @@ func (h *PostHandler) GetPostByID(c echo.Context) error {
 //	@Security		BearerAuth
 //	@Router			/posts [get]
 func (h *PostHandler) GetPosts(c echo.Context) error {
-	userID, ok := c.Get("userID").(int)
+	username, ok := c.Get("username").(string)
 	if !ok {
 		return c.JSON(http.StatusUnauthorized, dto.ErrorResponse{Error: "Unauthorized"})
 	}
@@ -159,7 +159,7 @@ func (h *PostHandler) GetPosts(c echo.Context) error {
 		limit = 10 // default limit
 	}
 
-	posts, err := h.postUseCase.GetPosts(c.Request().Context(), userID, limit, offset)
+	posts, err := h.postUseCase.GetPosts(c.Request().Context(), username, limit, offset)
 	if err != nil {
 		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Error: "Something went wrong"})
 	}
@@ -197,7 +197,7 @@ func (h *PostHandler) GetPosts(c echo.Context) error {
 //	@Security		BearerAuth
 //	@Router			/posts/{id} [put]
 func (h *PostHandler) UpdatePost(c echo.Context) error {
-	userID, ok := c.Get("userID").(int)
+	username, ok := c.Get("username").(string)
 	if !ok {
 		return c.JSON(http.StatusUnauthorized, dto.ErrorResponse{Error: "Unauthorized"})
 	}
@@ -213,7 +213,7 @@ func (h *PostHandler) UpdatePost(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: "Invalid request body"})
 	}
 
-	post, err := h.postUseCase.UpdatePost(c.Request().Context(), userID, id, req.Title, req.Content)
+	post, err := h.postUseCase.UpdatePost(c.Request().Context(), username, id, req.Title, req.Content)
 	if err != nil {
 		if errors.Is(err, domain.ErrPostNotFound) {
 			return c.JSON(http.StatusNotFound, dto.ErrorResponse{Error: "Post not found"})
@@ -248,7 +248,7 @@ func (h *PostHandler) UpdatePost(c echo.Context) error {
 //	@Security		BearerAuth
 //	@Router			/posts/{id} [delete]
 func (h *PostHandler) DeletePost(c echo.Context) error {
-	userID, ok := c.Get("userID").(int)
+	username, ok := c.Get("username").(string)
 	if !ok {
 		return c.JSON(http.StatusUnauthorized, dto.ErrorResponse{Error: "Unauthorized"})
 	}
@@ -259,7 +259,7 @@ func (h *PostHandler) DeletePost(c echo.Context) error {
 		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: "Post ID must be a number"})
 	}
 
-	err = h.postUseCase.DeletePost(c.Request().Context(), userID, id)
+	err = h.postUseCase.DeletePost(c.Request().Context(), username, id)
 	if err != nil {
 		if errors.Is(err, domain.ErrPostNotFound) {
 			return c.JSON(http.StatusNotFound, dto.ErrorResponse{Error: "Post not found"})
@@ -277,4 +277,51 @@ func (h *PostHandler) DeletePost(c echo.Context) error {
 		ID:      id,
 		Message: "Post deleted successfully",
 	})
+}
+
+// GetUserPosts handles the GET /users/:username/posts endpoint.
+//
+//	@Summary		Get user posts by username
+//	@Description	Retrieve all posts for a specific user by username.
+//	@Tags			posts
+//	@Produce		json
+//	@Param			username	path		string	true	"Username"
+//	@Param			limit		query		int		false	"Limit"
+//	@Param			offset		query		int		false	"Offset"
+//	@Success		200			{array}		dto.PostResponse
+//	@Failure		400			{object}	dto.ErrorResponse
+//	@Failure		500			{object}	dto.ErrorResponse
+//	@Router			/users/{username}/posts [get]
+func (h *PostHandler) GetUserPosts(c echo.Context) error {
+	username := c.Param("username")
+
+	limit, _ := strconv.Atoi(c.QueryParam("limit"))
+	offset, _ := strconv.Atoi(c.QueryParam("offset"))
+
+	if limit == 0 {
+		limit = 10 // default limit
+	}
+
+	posts, err := h.postUseCase.GetPosts(c.Request().Context(), username, limit, offset)
+	if err != nil {
+		if errors.Is(err, domain.ErrUserNotFound) || errors.Is(err, domain.ErrValidationFailed) {
+			return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: "User not found"})
+		}
+		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Error: "Something went wrong"})
+	}
+
+	response := make([]dto.PostResponse, 0, len(posts))
+	for _, p := range posts {
+		response = append(response, dto.PostResponse{
+			ID:        p.ID,
+			Title:     p.Title,
+			Content:   p.Content,
+			Tags:      p.Tags,
+			Author:    username,
+			CreatedAt: p.CreatedAt,
+			UpdatedAt: p.UpdatedAt,
+		})
+	}
+
+	return c.JSON(http.StatusOK, response)
 }

--- a/internal/core/domain/post.go
+++ b/internal/core/domain/post.go
@@ -15,7 +15,7 @@ var (
 // Post is the core domain entity representing a user's post.
 type Post struct {
 	ID        int
-	UserID    int
+	Username  string
 	Title     string
 	Content   string
 	Tags      []string

--- a/internal/core/ports/post.go
+++ b/internal/core/ports/post.go
@@ -11,25 +11,25 @@ type PostRepository interface {
 	// Create saves a new post to the repository.
 	Create(ctx context.Context, post *domain.Post) error
 	// GetByID retrieves a post by its ID.
-	GetByID(ctx context.Context, id int) (*domain.Post, error)
-	// GetPostsByUserID retrieves all posts for a specific user.
-	GetPostsByUserID(ctx context.Context, userID, limit, offset int) ([]*domain.Post, error)
+	GetByID(ctx context.Context, username string, id int) (*domain.Post, error)
+	// GetUserPosts retrieves all posts for a specific user.
+	GetUserPosts(ctx context.Context, username string, limit, offset int) ([]*domain.Post, error)
 	// Update updates an existing post in the repository.
-	Update(ctx context.Context, post *domain.Post) error
+	Update(ctx context.Context, username string, post *domain.Post) error
 	// Delete removes a post from the repository.
-	Delete(ctx context.Context, id int) error
+	Delete(ctx context.Context, username string, id int) error
 }
 
 // PostUseCase is a driving port for post-related application logic.
 type PostUseCase interface {
 	// CreatePost creates a new post with the given details.
-	CreatePost(ctx context.Context, userID int, title, content string, tags []string) (*domain.Post, error)
+	CreatePost(ctx context.Context, username string, title, content string, tags []string) (*domain.Post, error)
 	// GetPostByID retrieves a post by its ID for a specific user.
-	GetPostByID(ctx context.Context, userID, postID int) (*domain.Post, error)
+	GetPostByID(ctx context.Context, username string, postID int) (*domain.Post, error)
 	// GetPosts retrieves all posts for a specific user.
-	GetPosts(ctx context.Context, userID, limit, offset int) ([]*domain.Post, error)
+	GetPosts(ctx context.Context, username string, limit, offset int) ([]*domain.Post, error)
 	// UpdatePost updates an existing post for a specific user.
-	UpdatePost(ctx context.Context, userID, postID int, title, content string) (*domain.Post, error)
+	UpdatePost(ctx context.Context, username string, postID int, title, content string) (*domain.Post, error)
 	// DeletePost removes a post for a specific user.
-	DeletePost(ctx context.Context, userID, postID int) error
+	DeletePost(ctx context.Context, username string, postID int) error
 }

--- a/internal/core/usecase/mocks/mock_post.go
+++ b/internal/core/usecase/mocks/mock_post.go
@@ -56,61 +56,61 @@ func (mr *MockPostRepositoryMockRecorder) Create(ctx, post any) *gomock.Call {
 }
 
 // Delete mocks base method.
-func (m *MockPostRepository) Delete(ctx context.Context, id int) error {
+func (m *MockPostRepository) Delete(ctx context.Context, username string, id int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	ret := m.ctrl.Call(m, "Delete", ctx, username, id)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Delete indicates an expected call of Delete.
-func (mr *MockPostRepositoryMockRecorder) Delete(ctx, id any) *gomock.Call {
+func (mr *MockPostRepositoryMockRecorder) Delete(ctx, username, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockPostRepository)(nil).Delete), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockPostRepository)(nil).Delete), ctx, username, id)
 }
 
 // GetByID mocks base method.
-func (m *MockPostRepository) GetByID(ctx context.Context, id int) (*domain.Post, error) {
+func (m *MockPostRepository) GetByID(ctx context.Context, username string, id int) (*domain.Post, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetByID", ctx, id)
+	ret := m.ctrl.Call(m, "GetByID", ctx, username, id)
 	ret0, _ := ret[0].(*domain.Post)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetByID indicates an expected call of GetByID.
-func (mr *MockPostRepositoryMockRecorder) GetByID(ctx, id any) *gomock.Call {
+func (mr *MockPostRepositoryMockRecorder) GetByID(ctx, username, id any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByID", reflect.TypeOf((*MockPostRepository)(nil).GetByID), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetByID", reflect.TypeOf((*MockPostRepository)(nil).GetByID), ctx, username, id)
 }
 
-// GetPostsByUserID mocks base method.
-func (m *MockPostRepository) GetPostsByUserID(ctx context.Context, userID, limit, offset int) ([]*domain.Post, error) {
+// GetUserPosts mocks base method.
+func (m *MockPostRepository) GetUserPosts(ctx context.Context, username string, limit, offset int) ([]*domain.Post, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPostsByUserID", ctx, userID, limit, offset)
+	ret := m.ctrl.Call(m, "GetUserPosts", ctx, username, limit, offset)
 	ret0, _ := ret[0].([]*domain.Post)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetPostsByUserID indicates an expected call of GetPostsByUserID.
-func (mr *MockPostRepositoryMockRecorder) GetPostsByUserID(ctx, userID, limit, offset any) *gomock.Call {
+// GetUserPosts indicates an expected call of GetUserPosts.
+func (mr *MockPostRepositoryMockRecorder) GetUserPosts(ctx, username, limit, offset any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPostsByUserID", reflect.TypeOf((*MockPostRepository)(nil).GetPostsByUserID), ctx, userID, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUserPosts", reflect.TypeOf((*MockPostRepository)(nil).GetUserPosts), ctx, username, limit, offset)
 }
 
 // Update mocks base method.
-func (m *MockPostRepository) Update(ctx context.Context, post *domain.Post) error {
+func (m *MockPostRepository) Update(ctx context.Context, username string, post *domain.Post) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Update", ctx, post)
+	ret := m.ctrl.Call(m, "Update", ctx, username, post)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Update indicates an expected call of Update.
-func (mr *MockPostRepositoryMockRecorder) Update(ctx, post any) *gomock.Call {
+func (mr *MockPostRepositoryMockRecorder) Update(ctx, username, post any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockPostRepository)(nil).Update), ctx, post)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockPostRepository)(nil).Update), ctx, username, post)
 }
 
 // MockPostUseCase is a mock of PostUseCase interface.
@@ -138,75 +138,75 @@ func (m *MockPostUseCase) EXPECT() *MockPostUseCaseMockRecorder {
 }
 
 // CreatePost mocks base method.
-func (m *MockPostUseCase) CreatePost(ctx context.Context, userID int, title, content string, tags []string) (*domain.Post, error) {
+func (m *MockPostUseCase) CreatePost(ctx context.Context, username, title, content string, tags []string) (*domain.Post, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreatePost", ctx, userID, title, content, tags)
+	ret := m.ctrl.Call(m, "CreatePost", ctx, username, title, content, tags)
 	ret0, _ := ret[0].(*domain.Post)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // CreatePost indicates an expected call of CreatePost.
-func (mr *MockPostUseCaseMockRecorder) CreatePost(ctx, userID, title, content, tags any) *gomock.Call {
+func (mr *MockPostUseCaseMockRecorder) CreatePost(ctx, username, title, content, tags any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePost", reflect.TypeOf((*MockPostUseCase)(nil).CreatePost), ctx, userID, title, content, tags)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreatePost", reflect.TypeOf((*MockPostUseCase)(nil).CreatePost), ctx, username, title, content, tags)
 }
 
 // DeletePost mocks base method.
-func (m *MockPostUseCase) DeletePost(ctx context.Context, userID, postID int) error {
+func (m *MockPostUseCase) DeletePost(ctx context.Context, username string, postID int) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "DeletePost", ctx, userID, postID)
+	ret := m.ctrl.Call(m, "DeletePost", ctx, username, postID)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // DeletePost indicates an expected call of DeletePost.
-func (mr *MockPostUseCaseMockRecorder) DeletePost(ctx, userID, postID any) *gomock.Call {
+func (mr *MockPostUseCaseMockRecorder) DeletePost(ctx, username, postID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePost", reflect.TypeOf((*MockPostUseCase)(nil).DeletePost), ctx, userID, postID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeletePost", reflect.TypeOf((*MockPostUseCase)(nil).DeletePost), ctx, username, postID)
 }
 
 // GetPostByID mocks base method.
-func (m *MockPostUseCase) GetPostByID(ctx context.Context, userID, postID int) (*domain.Post, error) {
+func (m *MockPostUseCase) GetPostByID(ctx context.Context, username string, postID int) (*domain.Post, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPostByID", ctx, userID, postID)
+	ret := m.ctrl.Call(m, "GetPostByID", ctx, username, postID)
 	ret0, _ := ret[0].(*domain.Post)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPostByID indicates an expected call of GetPostByID.
-func (mr *MockPostUseCaseMockRecorder) GetPostByID(ctx, userID, postID any) *gomock.Call {
+func (mr *MockPostUseCaseMockRecorder) GetPostByID(ctx, username, postID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPostByID", reflect.TypeOf((*MockPostUseCase)(nil).GetPostByID), ctx, userID, postID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPostByID", reflect.TypeOf((*MockPostUseCase)(nil).GetPostByID), ctx, username, postID)
 }
 
 // GetPosts mocks base method.
-func (m *MockPostUseCase) GetPosts(ctx context.Context, userID, limit, offset int) ([]*domain.Post, error) {
+func (m *MockPostUseCase) GetPosts(ctx context.Context, username string, limit, offset int) ([]*domain.Post, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPosts", ctx, userID, limit, offset)
+	ret := m.ctrl.Call(m, "GetPosts", ctx, username, limit, offset)
 	ret0, _ := ret[0].([]*domain.Post)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPosts indicates an expected call of GetPosts.
-func (mr *MockPostUseCaseMockRecorder) GetPosts(ctx, userID, limit, offset any) *gomock.Call {
+func (mr *MockPostUseCaseMockRecorder) GetPosts(ctx, username, limit, offset any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPosts", reflect.TypeOf((*MockPostUseCase)(nil).GetPosts), ctx, userID, limit, offset)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPosts", reflect.TypeOf((*MockPostUseCase)(nil).GetPosts), ctx, username, limit, offset)
 }
 
 // UpdatePost mocks base method.
-func (m *MockPostUseCase) UpdatePost(ctx context.Context, userID, postID int, title, content string) (*domain.Post, error) {
+func (m *MockPostUseCase) UpdatePost(ctx context.Context, username string, postID int, title, content string) (*domain.Post, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "UpdatePost", ctx, userID, postID, title, content)
+	ret := m.ctrl.Call(m, "UpdatePost", ctx, username, postID, title, content)
 	ret0, _ := ret[0].(*domain.Post)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // UpdatePost indicates an expected call of UpdatePost.
-func (mr *MockPostUseCaseMockRecorder) UpdatePost(ctx, userID, postID, title, content any) *gomock.Call {
+func (mr *MockPostUseCaseMockRecorder) UpdatePost(ctx, username, postID, title, content any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePost", reflect.TypeOf((*MockPostUseCase)(nil).UpdatePost), ctx, userID, postID, title, content)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePost", reflect.TypeOf((*MockPostUseCase)(nil).UpdatePost), ctx, username, postID, title, content)
 }

--- a/internal/core/usecase/post_usecase.go
+++ b/internal/core/usecase/post_usecase.go
@@ -10,26 +10,21 @@ import (
 )
 
 type postUseCase struct {
-	repo     ports.PostRepository
-	userRepo ports.UserRepository
-	log      ports.Logger
+	repo ports.PostRepository
+	log  ports.Logger
 }
 
 // NewPostUseCase creates a new instance of ports.PostUseCase.
-func NewPostUseCase(repo ports.PostRepository, userRepo ports.UserRepository, log ports.Logger) ports.PostUseCase {
+func NewPostUseCase(repo ports.PostRepository, log ports.Logger) ports.PostUseCase {
 	if repo == nil {
 		panic("NewPostUseCase: repo is required")
-	}
-	if userRepo == nil {
-		panic("NewPostUseCase: userRepo is required")
 	}
 	if log == nil {
 		panic("NewPostUseCase: log is required")
 	}
 	return &postUseCase{
-		repo:     repo,
-		userRepo: userRepo,
-		log:      log,
+		repo: repo,
+		log:  log,
 	}
 }
 
@@ -88,11 +83,6 @@ func (s *postUseCase) UpdatePost(ctx context.Context, username string, postID in
 		}
 		s.log.Error(ctx, "failed to get post for update", "postID", postID, "username", username, "error", err)
 		return nil, domain.ErrInternalServer
-	}
-
-	if post.Username != username {
-		s.log.Error(ctx, "unauthorized update attempt", "postID", postID, "username", username)
-		return nil, domain.ErrUnauthorized
 	}
 
 	title = strings.TrimSpace(title)

--- a/internal/core/usecase/post_usecase.go
+++ b/internal/core/usecase/post_usecase.go
@@ -10,88 +10,88 @@ import (
 )
 
 type postUseCase struct {
-	repo ports.PostRepository
-	log  ports.Logger
+	repo     ports.PostRepository
+	userRepo ports.UserRepository
+	log      ports.Logger
 }
 
 // NewPostUseCase creates a new instance of ports.PostUseCase.
-func NewPostUseCase(repo ports.PostRepository, log ports.Logger) ports.PostUseCase {
+func NewPostUseCase(repo ports.PostRepository, userRepo ports.UserRepository, log ports.Logger) ports.PostUseCase {
 	if repo == nil {
 		panic("NewPostUseCase: repo is required")
+	}
+	if userRepo == nil {
+		panic("NewPostUseCase: userRepo is required")
 	}
 	if log == nil {
 		panic("NewPostUseCase: log is required")
 	}
 	return &postUseCase{
-		repo: repo,
-		log:  log,
+		repo:     repo,
+		userRepo: userRepo,
+		log:      log,
 	}
 }
 
-func (s *postUseCase) CreatePost(ctx context.Context, userID int, title, content string, tags []string) (*domain.Post, error) {
+func (s *postUseCase) CreatePost(ctx context.Context, username string, title, content string, tags []string) (*domain.Post, error) {
 	post := &domain.Post{
-		UserID:  userID,
-		Title:   title,
-		Content: content,
-		Tags:    tags,
+		Username: username,
+		Title:    title,
+		Content:  content,
+		Tags:     tags,
 	}
 
 	if err := s.repo.Create(ctx, post); err != nil {
-		s.log.Error(ctx, "failed to create post", "userID", userID, "error", err)
+		s.log.Error(ctx, "failed to create post", "username", username, "error", err)
 		return nil, domain.ErrInternalServer
 	}
 
-	s.log.Info(ctx, "post created successfully", "postID", post.ID, "userID", userID)
+	s.log.Info(ctx, "post created successfully", "postID", post.ID, "username", username)
 	return post, nil
 }
 
-func (s *postUseCase) GetPostByID(ctx context.Context, userID, id int) (*domain.Post, error) {
+func (s *postUseCase) GetPostByID(ctx context.Context, username string, id int) (*domain.Post, error) {
 	if id <= 0 {
 		return nil, domain.ErrInvalidPost
 	}
 
-	post, err := s.repo.GetByID(ctx, id)
+	post, err := s.repo.GetByID(ctx, username, id)
 	if err != nil {
 		if errors.Is(err, domain.ErrPostNotFound) {
 			return nil, err
 		}
-		s.log.Error(ctx, "failed to get post by id", "postID", id, "error", err)
+		s.log.Error(ctx, "failed to get post by id", "postID", id, "username", username, "error", err)
 		return nil, domain.ErrInternalServer
-	}
-
-	if post.UserID != userID {
-		s.log.Error(ctx, "unauthorized access to post", "postID", id, "userID", userID)
-		return nil, domain.ErrUnauthorized
 	}
 
 	return post, nil
 }
 
-func (s *postUseCase) GetPosts(ctx context.Context, userID, limit, offset int) ([]*domain.Post, error) {
-	posts, err := s.repo.GetPostsByUserID(ctx, userID, limit, offset)
+func (s *postUseCase) GetPosts(ctx context.Context, username string, limit, offset int) ([]*domain.Post, error) {
+	posts, err := s.repo.GetUserPosts(ctx, username, limit, offset)
 	if err != nil {
-		s.log.Error(ctx, "failed to get posts for user", "userID", userID, "error", err)
+		s.log.Error(ctx, "failed to get posts for user", "username", username, "error", err)
 		return nil, domain.ErrInternalServer
 	}
 	return posts, nil
 }
 
-func (s *postUseCase) UpdatePost(ctx context.Context, userID, postID int, title, content string) (*domain.Post, error) {
+func (s *postUseCase) UpdatePost(ctx context.Context, username string, postID int, title, content string) (*domain.Post, error) {
 	if postID <= 0 {
 		return nil, domain.ErrInvalidPost
 	}
 
-	post, err := s.repo.GetByID(ctx, postID)
+	post, err := s.repo.GetByID(ctx, username, postID)
 	if err != nil {
 		if errors.Is(err, domain.ErrPostNotFound) {
 			return nil, err
 		}
-		s.log.Error(ctx, "failed to get post for update", "postID", postID, "error", err)
+		s.log.Error(ctx, "failed to get post for update", "postID", postID, "username", username, "error", err)
 		return nil, domain.ErrInternalServer
 	}
 
-	if post.UserID != userID {
-		s.log.Error(ctx, "unauthorized update attempt", "postID", postID, "userID", userID)
+	if post.Username != username {
+		s.log.Error(ctx, "unauthorized update attempt", "postID", postID, "username", username)
 		return nil, domain.ErrUnauthorized
 	}
 
@@ -105,39 +105,25 @@ func (s *postUseCase) UpdatePost(ctx context.Context, userID, postID int, title,
 		post.Content = content
 	}
 
-	if err := s.repo.Update(ctx, post); err != nil {
+	if err := s.repo.Update(ctx, username, post); err != nil {
 		s.log.Error(ctx, "failed to update post", "postID", postID, "error", err)
 		return nil, domain.ErrInternalServer
 	}
 
-	s.log.Info(ctx, "post updated successfully", "postID", post.ID, "userID", userID)
+	s.log.Info(ctx, "post updated successfully", "postID", post.ID, "username", username)
 	return post, nil
 }
 
-func (s *postUseCase) DeletePost(ctx context.Context, userID, postID int) error {
+func (s *postUseCase) DeletePost(ctx context.Context, username string, postID int) error {
 	if postID <= 0 {
 		return domain.ErrInvalidPost
 	}
 
-	post, err := s.repo.GetByID(ctx, postID)
-	if err != nil {
-		if errors.Is(err, domain.ErrPostNotFound) {
-			return err
-		}
-		s.log.Error(ctx, "failed to get post for deletion", "postID", postID, "error", err)
-		return domain.ErrInternalServer
-	}
-
-	if post.UserID != userID {
-		s.log.Error(ctx, "unauthorized delete attempt", "postID", postID, "userID", userID)
-		return domain.ErrUnauthorized
-	}
-
-	if err := s.repo.Delete(ctx, postID); err != nil {
+	if err := s.repo.Delete(ctx, username, postID); err != nil {
 		s.log.Error(ctx, "failed to delete post", "postID", postID, "error", err)
 		return domain.ErrInternalServer
 	}
 
-	s.log.Info(ctx, "post deleted successfully", "postID", postID, "userID", userID)
+	s.log.Info(ctx, "post deleted successfully", "postID", postID, "username", username)
 	return nil
 }

--- a/internal/core/usecase/post_usecase_test.go
+++ b/internal/core/usecase/post_usecase_test.go
@@ -16,9 +16,8 @@ func TestPostUseCase_CreatePost(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockRepo := mocks.NewMockPostRepository(ctrl)
-	mockUserRepo := mocks.NewMockUserRepository(ctrl)
 	mockLog := mocks.NewMockLogger(ctrl)
-	svc := NewPostUseCase(mockRepo, mockUserRepo, mockLog)
+	svc := NewPostUseCase(mockRepo, mockLog)
 
 	ctx := context.Background()
 	username := "testuser"
@@ -63,9 +62,8 @@ func TestPostUseCase_GetPostByID(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockRepo := mocks.NewMockPostRepository(ctrl)
-	mockUserRepo := mocks.NewMockUserRepository(ctrl)
 	mockLog := mocks.NewMockLogger(ctrl)
-	svc := NewPostUseCase(mockRepo, mockUserRepo, mockLog)
+	svc := NewPostUseCase(mockRepo, mockLog)
 
 	ctx := context.Background()
 	username := "testuser"
@@ -116,9 +114,8 @@ func TestPostUseCase_GetPosts(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockRepo := mocks.NewMockPostRepository(ctrl)
-	mockUserRepo := mocks.NewMockUserRepository(ctrl)
 	mockLog := mocks.NewMockLogger(ctrl)
-	svc := NewPostUseCase(mockRepo, mockUserRepo, mockLog)
+	svc := NewPostUseCase(mockRepo, mockLog)
 
 	ctx := context.Background()
 	username := "testuser"
@@ -164,9 +161,8 @@ func TestPostUseCase_UpdatePost(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockRepo := mocks.NewMockPostRepository(ctrl)
-	mockUserRepo := mocks.NewMockUserRepository(ctrl)
 	mockLog := mocks.NewMockLogger(ctrl)
-	svc := NewPostUseCase(mockRepo, mockUserRepo, mockLog)
+	svc := NewPostUseCase(mockRepo, mockLog)
 
 	ctx := context.Background()
 	username := "testuser"
@@ -232,18 +228,6 @@ func TestPostUseCase_UpdatePost(t *testing.T) {
 		assert.Equal(t, newContent, post.Content)
 	})
 
-	t.Run("unauthorized update", func(t *testing.T) {
-		existingPost := &domain.Post{ID: postID, Username: "otheruser", Title: initialTitle, Content: initialContent}
-		mockRepo.EXPECT().GetByID(ctx, username, postID).Return(existingPost, nil)
-		mockLog.EXPECT().Error(ctx, "unauthorized update attempt", "postID", postID, "username", username)
-
-		post, err := svc.UpdatePost(ctx, username, postID, "New Title", "New Content")
-
-		assert.Error(t, err)
-		assert.Nil(t, post)
-		assert.True(t, errors.Is(err, domain.ErrUnauthorized))
-	})
-
 	t.Run("not found", func(t *testing.T) {
 		mockRepo.EXPECT().GetByID(ctx, username, postID).Return(nil, domain.ErrPostNotFound)
 
@@ -268,9 +252,8 @@ func TestPostUseCase_DeletePost(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockRepo := mocks.NewMockPostRepository(ctrl)
-	mockUserRepo := mocks.NewMockUserRepository(ctrl)
 	mockLog := mocks.NewMockLogger(ctrl)
-	svc := NewPostUseCase(mockRepo, mockUserRepo, mockLog)
+	svc := NewPostUseCase(mockRepo, mockLog)
 
 	ctx := context.Background()
 	username := "testuser"

--- a/internal/core/usecase/post_usecase_test.go
+++ b/internal/core/usecase/post_usecase_test.go
@@ -16,11 +16,12 @@ func TestPostUseCase_CreatePost(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockRepo := mocks.NewMockPostRepository(ctrl)
+	mockUserRepo := mocks.NewMockUserRepository(ctrl)
 	mockLog := mocks.NewMockLogger(ctrl)
-	svc := NewPostUseCase(mockRepo, mockLog)
+	svc := NewPostUseCase(mockRepo, mockUserRepo, mockLog)
 
 	ctx := context.Background()
-	userID := 1
+	username := "testuser"
 	title := "Test Title"
 	content := "Test Content"
 	tags := []string{"tag1", "tag2"}
@@ -32,23 +33,24 @@ func TestPostUseCase_CreatePost(t *testing.T) {
 				post.ID = 1
 				return nil
 			})
-		mockLog.EXPECT().Info(ctx, "post created successfully", "postID", gomock.Any(), "userID", gomock.Any())
+		mockLog.EXPECT().Info(ctx, "post created successfully", "postID", gomock.Any(), "username", username)
 
-		post, err := svc.CreatePost(ctx, userID, title, content, tags)
+		post, err := svc.CreatePost(ctx, username, title, content, tags)
 
 		assert.NoError(t, err)
 		assert.NotNil(t, post)
 		assert.Equal(t, 1, post.ID)
 		assert.Equal(t, title, post.Title)
+		assert.Equal(t, username, post.Username)
 	})
 
 	t.Run("repository error", func(t *testing.T) {
 		mockRepo.EXPECT().
 			Create(ctx, gomock.Any()).
 			Return(errors.New("db error"))
-		mockLog.EXPECT().Error(ctx, "failed to create post", "userID", gomock.Any(), "error", gomock.Any())
+		mockLog.EXPECT().Error(ctx, "failed to create post", "username", username, "error", gomock.Any())
 
-		post, err := svc.CreatePost(ctx, userID, title, content, tags)
+		post, err := svc.CreatePost(ctx, username, title, content, tags)
 
 		assert.Error(t, err)
 		assert.Nil(t, post)
@@ -61,27 +63,28 @@ func TestPostUseCase_GetPostByID(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockRepo := mocks.NewMockPostRepository(ctrl)
+	mockUserRepo := mocks.NewMockUserRepository(ctrl)
 	mockLog := mocks.NewMockLogger(ctrl)
-	svc := NewPostUseCase(mockRepo, mockLog)
+	svc := NewPostUseCase(mockRepo, mockUserRepo, mockLog)
 
 	ctx := context.Background()
-	userID := 1
+	username := "testuser"
 	postID := 1
 
 	t.Run("success", func(t *testing.T) {
-		expectedPost := &domain.Post{ID: postID, UserID: userID, Title: "Test Title"}
-		mockRepo.EXPECT().GetByID(ctx, postID).Return(expectedPost, nil)
+		expectedPost := &domain.Post{ID: postID, Username: username, Title: "Test Title"}
+		mockRepo.EXPECT().GetByID(ctx, username, postID).Return(expectedPost, nil)
 
-		post, err := svc.GetPostByID(ctx, userID, postID)
+		post, err := svc.GetPostByID(ctx, username, postID)
 
 		assert.NoError(t, err)
 		assert.Equal(t, expectedPost, post)
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		mockRepo.EXPECT().GetByID(ctx, postID).Return(nil, domain.ErrPostNotFound)
+		mockRepo.EXPECT().GetByID(ctx, username, postID).Return(nil, domain.ErrPostNotFound)
 
-		post, err := svc.GetPostByID(ctx, userID, postID)
+		post, err := svc.GetPostByID(ctx, username, postID)
 
 		assert.Error(t, err)
 		assert.Nil(t, post)
@@ -89,10 +92,10 @@ func TestPostUseCase_GetPostByID(t *testing.T) {
 	})
 
 	t.Run("repository error", func(t *testing.T) {
-		mockRepo.EXPECT().GetByID(ctx, postID).Return(nil, errors.New("db error"))
-		mockLog.EXPECT().Error(ctx, "failed to get post by id", "postID", postID, "error", gomock.Any())
+		mockRepo.EXPECT().GetByID(ctx, username, postID).Return(nil, errors.New("db error"))
+		mockLog.EXPECT().Error(ctx, "failed to get post by id", "postID", postID, "username", username, "error", gomock.Any())
 
-		post, err := svc.GetPostByID(ctx, userID, postID)
+		post, err := svc.GetPostByID(ctx, username, postID)
 
 		assert.Error(t, err)
 		assert.Nil(t, post)
@@ -100,23 +103,11 @@ func TestPostUseCase_GetPostByID(t *testing.T) {
 	})
 
 	t.Run("invalid id", func(t *testing.T) {
-		post, err := svc.GetPostByID(ctx, userID, 0)
+		post, err := svc.GetPostByID(ctx, username, 0)
 
 		assert.Error(t, err)
 		assert.Nil(t, post)
 		assert.True(t, errors.Is(err, domain.ErrInvalidPost))
-	})
-
-	t.Run("unauthorized access", func(t *testing.T) {
-		expectedPost := &domain.Post{ID: postID, UserID: 2, Title: "Test Title"} // Belongs to a different user
-		mockRepo.EXPECT().GetByID(ctx, postID).Return(expectedPost, nil)
-		mockLog.EXPECT().Error(ctx, "unauthorized access to post", "postID", postID, "userID", userID)
-
-		post, err := svc.GetPostByID(ctx, userID, postID)
-
-		assert.Error(t, err)
-		assert.Nil(t, post)
-		assert.True(t, errors.Is(err, domain.ErrUnauthorized))
 	})
 }
 
@@ -125,41 +116,42 @@ func TestPostUseCase_GetPosts(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockRepo := mocks.NewMockPostRepository(ctrl)
+	mockUserRepo := mocks.NewMockUserRepository(ctrl)
 	mockLog := mocks.NewMockLogger(ctrl)
-	svc := NewPostUseCase(mockRepo, mockLog)
+	svc := NewPostUseCase(mockRepo, mockUserRepo, mockLog)
 
 	ctx := context.Background()
-	userID := 1
+	username := "testuser"
 	limit := 10
 	offset := 0
 
 	t.Run("success", func(t *testing.T) {
 		expectedPosts := []*domain.Post{
-			{ID: 1, UserID: userID, Title: "Post 1"},
-			{ID: 2, UserID: userID, Title: "Post 2"},
+			{ID: 1, Username: username, Title: "Post 1"},
+			{ID: 2, Username: username, Title: "Post 2"},
 		}
-		mockRepo.EXPECT().GetPostsByUserID(ctx, userID, limit, offset).Return(expectedPosts, nil)
+		mockRepo.EXPECT().GetUserPosts(ctx, username, limit, offset).Return(expectedPosts, nil)
 
-		posts, err := svc.GetPosts(ctx, userID, limit, offset)
+		posts, err := svc.GetPosts(ctx, username, limit, offset)
 
 		assert.NoError(t, err)
 		assert.Equal(t, expectedPosts, posts)
 	})
 
 	t.Run("empty results", func(t *testing.T) {
-		mockRepo.EXPECT().GetPostsByUserID(ctx, userID, limit, offset).Return([]*domain.Post{}, nil)
+		mockRepo.EXPECT().GetUserPosts(ctx, username, limit, offset).Return([]*domain.Post{}, nil)
 
-		posts, err := svc.GetPosts(ctx, userID, limit, offset)
+		posts, err := svc.GetPosts(ctx, username, limit, offset)
 
 		assert.NoError(t, err)
 		assert.Empty(t, posts)
 	})
 
 	t.Run("repository error", func(t *testing.T) {
-		mockRepo.EXPECT().GetPostsByUserID(ctx, userID, limit, offset).Return(nil, errors.New("db error"))
-		mockLog.EXPECT().Error(ctx, "failed to get posts for user", "userID", userID, "error", gomock.Any())
+		mockRepo.EXPECT().GetUserPosts(ctx, username, limit, offset).Return(nil, errors.New("db error"))
+		mockLog.EXPECT().Error(ctx, "failed to get posts for user", "username", username, "error", gomock.Any())
 
-		posts, err := svc.GetPosts(ctx, userID, limit, offset)
+		posts, err := svc.GetPosts(ctx, username, limit, offset)
 
 		assert.Error(t, err)
 		assert.Nil(t, posts)
@@ -172,29 +164,30 @@ func TestPostUseCase_UpdatePost(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockRepo := mocks.NewMockPostRepository(ctrl)
+	mockUserRepo := mocks.NewMockUserRepository(ctrl)
 	mockLog := mocks.NewMockLogger(ctrl)
-	svc := NewPostUseCase(mockRepo, mockLog)
+	svc := NewPostUseCase(mockRepo, mockUserRepo, mockLog)
 
 	ctx := context.Background()
-	userID := 1
+	username := "testuser"
 	postID := 1
 	initialTitle := "Old Title"
 	initialContent := "Old Content"
 
 	t.Run("success full update", func(t *testing.T) {
-		existingPost := &domain.Post{ID: postID, UserID: userID, Title: initialTitle, Content: initialContent}
+		existingPost := &domain.Post{ID: postID, Username: username, Title: initialTitle, Content: initialContent}
 		newTitle := "New Title"
 		newContent := "New Content"
 
-		mockRepo.EXPECT().GetByID(ctx, postID).Return(existingPost, nil)
-		mockRepo.EXPECT().Update(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, post *domain.Post) error {
+		mockRepo.EXPECT().GetByID(ctx, username, postID).Return(existingPost, nil)
+		mockRepo.EXPECT().Update(ctx, username, gomock.Any()).DoAndReturn(func(ctx context.Context, username string, post *domain.Post) error {
 			assert.Equal(t, newTitle, post.Title)
 			assert.Equal(t, newContent, post.Content)
 			return nil
 		})
-		mockLog.EXPECT().Info(ctx, "post updated successfully", "postID", postID, "userID", userID)
+		mockLog.EXPECT().Info(ctx, "post updated successfully", "postID", postID, "username", username)
 
-		post, err := svc.UpdatePost(ctx, userID, postID, newTitle, newContent)
+		post, err := svc.UpdatePost(ctx, username, postID, newTitle, newContent)
 
 		assert.NoError(t, err)
 		assert.Equal(t, newTitle, post.Title)
@@ -202,18 +195,18 @@ func TestPostUseCase_UpdatePost(t *testing.T) {
 	})
 
 	t.Run("success partial update - title only", func(t *testing.T) {
-		existingPost := &domain.Post{ID: postID, UserID: userID, Title: initialTitle, Content: initialContent}
+		existingPost := &domain.Post{ID: postID, Username: username, Title: initialTitle, Content: initialContent}
 		newTitle := "New Title"
 
-		mockRepo.EXPECT().GetByID(ctx, postID).Return(existingPost, nil)
-		mockRepo.EXPECT().Update(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, post *domain.Post) error {
+		mockRepo.EXPECT().GetByID(ctx, username, postID).Return(existingPost, nil)
+		mockRepo.EXPECT().Update(ctx, username, gomock.Any()).DoAndReturn(func(ctx context.Context, username string, post *domain.Post) error {
 			assert.Equal(t, newTitle, post.Title)
 			assert.Equal(t, initialContent, post.Content)
 			return nil
 		})
-		mockLog.EXPECT().Info(ctx, "post updated successfully", "postID", postID, "userID", userID)
+		mockLog.EXPECT().Info(ctx, "post updated successfully", "postID", postID, "username", username)
 
-		post, err := svc.UpdatePost(ctx, userID, postID, newTitle, "")
+		post, err := svc.UpdatePost(ctx, username, postID, newTitle, "")
 
 		assert.NoError(t, err)
 		assert.Equal(t, newTitle, post.Title)
@@ -221,18 +214,18 @@ func TestPostUseCase_UpdatePost(t *testing.T) {
 	})
 
 	t.Run("success partial update - content only", func(t *testing.T) {
-		existingPost := &domain.Post{ID: postID, UserID: userID, Title: initialTitle, Content: initialContent}
+		existingPost := &domain.Post{ID: postID, Username: username, Title: initialTitle, Content: initialContent}
 		newContent := "New Content"
 
-		mockRepo.EXPECT().GetByID(ctx, postID).Return(existingPost, nil)
-		mockRepo.EXPECT().Update(ctx, gomock.Any()).DoAndReturn(func(ctx context.Context, post *domain.Post) error {
+		mockRepo.EXPECT().GetByID(ctx, username, postID).Return(existingPost, nil)
+		mockRepo.EXPECT().Update(ctx, username, gomock.Any()).DoAndReturn(func(ctx context.Context, username string, post *domain.Post) error {
 			assert.Equal(t, initialTitle, post.Title)
 			assert.Equal(t, newContent, post.Content)
 			return nil
 		})
-		mockLog.EXPECT().Info(ctx, "post updated successfully", "postID", postID, "userID", userID)
+		mockLog.EXPECT().Info(ctx, "post updated successfully", "postID", postID, "username", username)
 
-		post, err := svc.UpdatePost(ctx, userID, postID, "", newContent)
+		post, err := svc.UpdatePost(ctx, username, postID, "", newContent)
 
 		assert.NoError(t, err)
 		assert.Equal(t, initialTitle, post.Title)
@@ -240,11 +233,11 @@ func TestPostUseCase_UpdatePost(t *testing.T) {
 	})
 
 	t.Run("unauthorized update", func(t *testing.T) {
-		existingPost := &domain.Post{ID: postID, UserID: 2, Title: initialTitle, Content: initialContent}
-		mockRepo.EXPECT().GetByID(ctx, postID).Return(existingPost, nil)
-		mockLog.EXPECT().Error(ctx, "unauthorized update attempt", "postID", postID, "userID", userID)
+		existingPost := &domain.Post{ID: postID, Username: "otheruser", Title: initialTitle, Content: initialContent}
+		mockRepo.EXPECT().GetByID(ctx, username, postID).Return(existingPost, nil)
+		mockLog.EXPECT().Error(ctx, "unauthorized update attempt", "postID", postID, "username", username)
 
-		post, err := svc.UpdatePost(ctx, userID, postID, "New Title", "New Content")
+		post, err := svc.UpdatePost(ctx, username, postID, "New Title", "New Content")
 
 		assert.Error(t, err)
 		assert.Nil(t, post)
@@ -252,9 +245,9 @@ func TestPostUseCase_UpdatePost(t *testing.T) {
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		mockRepo.EXPECT().GetByID(ctx, postID).Return(nil, domain.ErrPostNotFound)
+		mockRepo.EXPECT().GetByID(ctx, username, postID).Return(nil, domain.ErrPostNotFound)
 
-		post, err := svc.UpdatePost(ctx, userID, postID, "New Title", "New Content")
+		post, err := svc.UpdatePost(ctx, username, postID, "New Title", "New Content")
 
 		assert.Error(t, err)
 		assert.Nil(t, post)
@@ -262,7 +255,7 @@ func TestPostUseCase_UpdatePost(t *testing.T) {
 	})
 
 	t.Run("invalid id", func(t *testing.T) {
-		post, err := svc.UpdatePost(ctx, userID, 0, "New Title", "New Content")
+		post, err := svc.UpdatePost(ctx, username, 0, "New Title", "New Content")
 
 		assert.Error(t, err)
 		assert.Nil(t, post)
@@ -275,58 +268,35 @@ func TestPostUseCase_DeletePost(t *testing.T) {
 	defer ctrl.Finish()
 
 	mockRepo := mocks.NewMockPostRepository(ctrl)
+	mockUserRepo := mocks.NewMockUserRepository(ctrl)
 	mockLog := mocks.NewMockLogger(ctrl)
-	svc := NewPostUseCase(mockRepo, mockLog)
+	svc := NewPostUseCase(mockRepo, mockUserRepo, mockLog)
 
 	ctx := context.Background()
-	userID := 1
+	username := "testuser"
 	postID := 1
 
 	t.Run("success", func(t *testing.T) {
-		existingPost := &domain.Post{ID: postID, UserID: userID}
-		mockRepo.EXPECT().GetByID(ctx, postID).Return(existingPost, nil)
-		mockRepo.EXPECT().Delete(ctx, postID).Return(nil)
-		mockLog.EXPECT().Info(ctx, "post deleted successfully", "postID", postID, "userID", userID)
+		mockRepo.EXPECT().Delete(ctx, username, postID).Return(nil)
+		mockLog.EXPECT().Info(ctx, "post deleted successfully", "postID", postID, "username", username)
 
-		err := svc.DeletePost(ctx, userID, postID)
+		err := svc.DeletePost(ctx, username, postID)
 
 		assert.NoError(t, err)
 	})
 
-	t.Run("not found", func(t *testing.T) {
-		mockRepo.EXPECT().GetByID(ctx, postID).Return(nil, domain.ErrPostNotFound)
-
-		err := svc.DeletePost(ctx, userID, postID)
-
-		assert.Error(t, err)
-		assert.True(t, errors.Is(err, domain.ErrPostNotFound))
-	})
-
-	t.Run("unauthorized delete", func(t *testing.T) {
-		existingPost := &domain.Post{ID: postID, UserID: 2}
-		mockRepo.EXPECT().GetByID(ctx, postID).Return(existingPost, nil)
-		mockLog.EXPECT().Error(ctx, "unauthorized delete attempt", "postID", postID, "userID", userID)
-
-		err := svc.DeletePost(ctx, userID, postID)
-
-		assert.Error(t, err)
-		assert.True(t, errors.Is(err, domain.ErrUnauthorized))
-	})
-
 	t.Run("repository error on delete", func(t *testing.T) {
-		existingPost := &domain.Post{ID: postID, UserID: userID}
-		mockRepo.EXPECT().GetByID(ctx, postID).Return(existingPost, nil)
-		mockRepo.EXPECT().Delete(ctx, postID).Return(errors.New("db error"))
+		mockRepo.EXPECT().Delete(ctx, username, postID).Return(errors.New("db error"))
 		mockLog.EXPECT().Error(ctx, "failed to delete post", "postID", postID, "error", gomock.Any())
 
-		err := svc.DeletePost(ctx, userID, postID)
+		err := svc.DeletePost(ctx, username, postID)
 
 		assert.Error(t, err)
 		assert.True(t, errors.Is(err, domain.ErrInternalServer))
 	})
 
 	t.Run("invalid id", func(t *testing.T) {
-		err := svc.DeletePost(ctx, userID, 0)
+		err := svc.DeletePost(ctx, username, 0)
 
 		assert.Error(t, err)
 		assert.True(t, errors.Is(err, domain.ErrInvalidPost))


### PR DESCRIPTION
This PR implements the functionality to retrieve all posts for a specific user by username.

### Changes:
- Updated post domain, ports, and usecase to use username instead of userID.
- Refactored post repository to support username-based queries.
- Updated API handlers and registered the new route GET /users/:username/posts.
- Updated Swagger documentation.
- Fixed and updated unit tests for the post usecase.

Closes #60