### PR TITLE
Implement Delete a Comment feature

### DIFF
--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -249,6 +249,12 @@ const docTemplate = `{
                             "$ref": "#/definitions/dto.MessageResponse"
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {

--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -221,6 +221,53 @@ const docTemplate = `{
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete an existing comment by the author.",
+                "tags": [
+                    "comments"
+                ],
+                "summary": "Delete comment",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Comment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.MessageResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/posts": {

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -215,6 +215,53 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "security": [
+                    {
+                        "BearerAuth": []
+                    }
+                ],
+                "description": "Delete an existing comment by the author.",
+                "tags": [
+                    "comments"
+                ],
+                "summary": "Delete comment",
+                "parameters": [
+                    {
+                        "type": "integer",
+                        "description": "Comment ID",
+                        "name": "id",
+                        "in": "path",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/dto.MessageResponse"
+                        }
+                    },
+                    "401": {
+                        "description": "Unauthorized",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "404": {
+                        "description": "Not Found",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    }
+                }
             }
         },
         "/posts": {

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -243,6 +243,12 @@
                             "$ref": "#/definitions/dto.MessageResponse"
                         }
                     },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/dto.ErrorResponse"
+                        }
+                    },
                     "401": {
                         "description": "Unauthorized",
                         "schema": {

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -294,6 +294,36 @@ paths:
       tags:
       - users
   /comments/{id}:
+    delete:
+      description: Delete an existing comment by the author.
+      parameters:
+      - description: Comment ID
+        in: path
+        name: id
+        required: true
+        type: integer
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/dto.MessageResponse'
+        "401":
+          description: Unauthorized
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+        "404":
+          description: Not Found
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+        "500":
+          description: Internal Server Error
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
+      security:
+      - BearerAuth: []
+      summary: Delete comment
+      tags:
+      - comments
     put:
       consumes:
       - application/json

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -307,6 +307,10 @@ paths:
           description: OK
           schema:
             $ref: '#/definitions/dto.MessageResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/dto.ErrorResponse'
         "401":
           description: Unauthorized
           schema:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -137,6 +137,7 @@ func main() {
 	comments := e.Group("/comments", middleware.Authorize(tokenSvc))
 	{
 		comments.PUT("/:id", commentHdl.EditComment)
+		comments.DELETE("/:id", commentHdl.DeleteComment)
 	}
 
 	// Start server.

--- a/internal/adapters/repository/comment_repository.go
+++ b/internal/adapters/repository/comment_repository.go
@@ -102,3 +102,11 @@ func (r *commentRepository) Update(ctx context.Context, comment *domain.Comment)
 	comment.UpdatedAt = m.UpdatedAt
 	return nil
 }
+
+func (r *commentRepository) Delete(ctx context.Context, id int) error {
+	err := r.db.WithContext(ctx).Delete(&commentModel{}, id).Error
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/internal/api/handler/comment_handler.go
+++ b/internal/api/handler/comment_handler.go
@@ -151,6 +151,7 @@ func (h *CommentHandler) EditComment(c echo.Context) error {
 //	@Tags			comments
 //	@Param			id	path		int	true	"Comment ID"
 //	@Success		200	{object}	dto.MessageResponse
+//	@Failure		400	{object}	dto.ErrorResponse
 //	@Failure		401	{object}	dto.ErrorResponse
 //	@Failure		404	{object}	dto.ErrorResponse
 //	@Failure		500	{object}	dto.ErrorResponse
@@ -164,8 +165,8 @@ func (h *CommentHandler) DeleteComment(c echo.Context) error {
 
 	idStr := c.Param("id")
 	id, err := strconv.Atoi(idStr)
-	if err != nil {
-		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: "Invalid request body"})
+	if err != nil || id <= 0 {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: "Invalid comment ID"})
 	}
 
 	err = h.commentUseCase.DeleteComment(c.Request().Context(), id, username)
@@ -179,5 +180,5 @@ func (h *CommentHandler) DeleteComment(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Error: "Something went wrong"})
 	}
 
-	return c.JSON(http.StatusOK, dto.MessageResponse{Message: "Comment deleted succesfuly"})
+	return c.JSON(http.StatusOK, dto.MessageResponse{Message: "Comment deleted successfully"})
 }

--- a/internal/api/handler/comment_handler.go
+++ b/internal/api/handler/comment_handler.go
@@ -143,3 +143,41 @@ func (h *CommentHandler) EditComment(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, dto.MessageResponse{Message: "Comment updated succesfully"})
 }
+
+// DeleteComment handles the DELETE /comments/:id endpoint.
+//
+//	@Summary		Delete comment
+//	@Description	Delete an existing comment by the author.
+//	@Tags			comments
+//	@Param			id	path		int	true	"Comment ID"
+//	@Success		200	{object}	dto.MessageResponse
+//	@Failure		401	{object}	dto.ErrorResponse
+//	@Failure		404	{object}	dto.ErrorResponse
+//	@Failure		500	{object}	dto.ErrorResponse
+//	@Security		BearerAuth
+//	@Router			/comments/{id} [delete]
+func (h *CommentHandler) DeleteComment(c echo.Context) error {
+	username, ok := c.Get("username").(string)
+	if !ok {
+		return c.JSON(http.StatusUnauthorized, dto.ErrorResponse{Error: "Unauthorized"})
+	}
+
+	idStr := c.Param("id")
+	id, err := strconv.Atoi(idStr)
+	if err != nil {
+		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: "Invalid request body"})
+	}
+
+	err = h.commentUseCase.DeleteComment(c.Request().Context(), id, username)
+	if err != nil {
+		if errors.Is(err, domain.ErrCommentNotFound) {
+			return c.JSON(http.StatusNotFound, dto.ErrorResponse{Error: "Comment not found"})
+		}
+		if errors.Is(err, domain.ErrUnauthorized) {
+			return c.JSON(http.StatusUnauthorized, dto.ErrorResponse{Error: "Unauthorized"})
+		}
+		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Error: "Something went wrong"})
+	}
+
+	return c.JSON(http.StatusOK, dto.MessageResponse{Message: "Comment deleted succesfuly"})
+}

--- a/internal/core/ports/comment.go
+++ b/internal/core/ports/comment.go
@@ -16,6 +16,8 @@ type CommentRepository interface {
 	GetByID(ctx context.Context, id int) (*domain.Comment, error)
 	// Update updates a comment's details.
 	Update(ctx context.Context, comment *domain.Comment) error
+	// Delete removes a comment by its ID from the repository.
+	Delete(ctx context.Context, id int) error
 }
 
 // CommentUseCase is a driving port for comment-related application logic.
@@ -26,4 +28,6 @@ type CommentUseCase interface {
 	GetCommentsByPostID(ctx context.Context, postID int) ([]*domain.Comment, error)
 	// EditComment updates an existing comment's content.
 	EditComment(ctx context.Context, id int, username string, content string) error
+	// DeleteComment deletes a comment if it belongs to the user.
+	DeleteComment(ctx context.Context, id int, username string) error
 }

--- a/internal/core/usecase/comment_usecase.go
+++ b/internal/core/usecase/comment_usecase.go
@@ -118,3 +118,33 @@ func (u *commentUseCase) EditComment(ctx context.Context, id int, username strin
 	u.log.Info(ctx, "comment updated successfully", "commentID", id, "username", username)
 	return nil
 }
+
+func (u *commentUseCase) DeleteComment(ctx context.Context, id int, username string) error {
+	// 1. Fetch current comment
+	comment, err := u.commentRepo.GetByID(ctx, id)
+	if err != nil {
+		if errors.Is(err, domain.ErrCommentNotFound) {
+			return err
+		}
+		u.log.Error(ctx, "failed to fetch comment for delete", "commentID", id, "error", err)
+		return domain.ErrInternalServer
+	}
+	if comment == nil {
+		return domain.ErrCommentNotFound
+	}
+
+	// 2. Authorize: only author can delete
+	if comment.Username != username {
+		u.log.Warn(ctx, "unauthorized attempt to delete comment", "commentID", id, "attemptedBy", username, "actualAuthor", comment.Username)
+		return domain.ErrUnauthorized
+	}
+
+	// 3. Persist deletion
+	if err := u.commentRepo.Delete(ctx, id); err != nil {
+		u.log.Error(ctx, "failed to delete comment in repository", "commentID", id, "error", err)
+		return domain.ErrInternalServer
+	}
+
+	u.log.Info(ctx, "comment deleted successfully", "commentID", id, "username", username)
+	return nil
+}

--- a/internal/core/usecase/comment_usecase_test.go
+++ b/internal/core/usecase/comment_usecase_test.go
@@ -250,3 +250,107 @@ func TestCommentUseCase_EditComment(t *testing.T) {
 		assert.True(t, errors.Is(err, domain.ErrInternalServer))
 	})
 }
+
+func TestCommentUseCase_DeleteComment(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockCommentRepo := mocks.NewMockCommentRepository(ctrl)
+	mockPostRepo := mocks.NewMockPostRepository(ctrl)
+	mockUserRepo := mocks.NewMockUserRepository(ctrl)
+	mockLog := mocks.NewMockLogger(ctrl)
+
+	svc := NewCommentUseCase(mockCommentRepo, mockPostRepo, mockUserRepo, mockLog)
+
+	ctx := context.Background()
+	commentID := 1
+	authorUsername := "author"
+	nonAuthorUsername := "hacker"
+
+	t.Run("success", func(t *testing.T) {
+		existingComment := &domain.Comment{
+			ID:       commentID,
+			Username: authorUsername,
+		}
+		mockCommentRepo.EXPECT().
+			GetByID(ctx, commentID).
+			Return(existingComment, nil)
+
+		mockCommentRepo.EXPECT().
+			Delete(ctx, commentID).
+			Return(nil)
+
+		mockLog.EXPECT().Info(ctx, "comment deleted successfully", "commentID", commentID, "username", authorUsername)
+
+		err := svc.DeleteComment(ctx, commentID, authorUsername)
+		assert.NoError(t, err)
+	})
+
+	t.Run("comment not found - error", func(t *testing.T) {
+		mockCommentRepo.EXPECT().
+			GetByID(ctx, commentID).
+			Return(nil, domain.ErrCommentNotFound)
+
+		err := svc.DeleteComment(ctx, commentID, authorUsername)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, domain.ErrCommentNotFound))
+	})
+
+	t.Run("comment not found - other repo error", func(t *testing.T) {
+		mockCommentRepo.EXPECT().
+			GetByID(ctx, commentID).
+			Return(nil, errors.New("db error"))
+
+		mockLog.EXPECT().Error(ctx, "failed to fetch comment for delete", "commentID", commentID, "error", gomock.Any())
+
+		err := svc.DeleteComment(ctx, commentID, authorUsername)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, domain.ErrInternalServer))
+	})
+
+	t.Run("comment is nil", func(t *testing.T) {
+		mockCommentRepo.EXPECT().
+			GetByID(ctx, commentID).
+			Return(nil, nil)
+
+		err := svc.DeleteComment(ctx, commentID, authorUsername)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, domain.ErrCommentNotFound))
+	})
+
+	t.Run("unauthorized", func(t *testing.T) {
+		existingComment := &domain.Comment{
+			ID:       commentID,
+			Username: authorUsername,
+		}
+		mockCommentRepo.EXPECT().
+			GetByID(ctx, commentID).
+			Return(existingComment, nil)
+
+		mockLog.EXPECT().Warn(ctx, "unauthorized attempt to delete comment", "commentID", commentID, "attemptedBy", nonAuthorUsername, "actualAuthor", authorUsername)
+
+		err := svc.DeleteComment(ctx, commentID, nonAuthorUsername)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, domain.ErrUnauthorized))
+	})
+
+	t.Run("repository delete error", func(t *testing.T) {
+		existingComment := &domain.Comment{
+			ID:       commentID,
+			Username: authorUsername,
+		}
+		mockCommentRepo.EXPECT().
+			GetByID(ctx, commentID).
+			Return(existingComment, nil)
+
+		mockCommentRepo.EXPECT().
+			Delete(ctx, commentID).
+			Return(errors.New("db delete error"))
+
+		mockLog.EXPECT().Error(ctx, "failed to delete comment in repository", "commentID", commentID, "error", gomock.Any())
+
+		err := svc.DeleteComment(ctx, commentID, authorUsername)
+		assert.Error(t, err)
+		assert.True(t, errors.Is(err, domain.ErrInternalServer))
+	})
+}

--- a/internal/core/usecase/mocks/mock_comment.go
+++ b/internal/core/usecase/mocks/mock_comment.go
@@ -55,6 +55,20 @@ func (mr *MockCommentRepositoryMockRecorder) Create(ctx, comment any) *gomock.Ca
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockCommentRepository)(nil).Create), ctx, comment)
 }
 
+// Delete mocks base method.
+func (m *MockCommentRepository) Delete(ctx context.Context, id int) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", ctx, id)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// Delete indicates an expected call of Delete.
+func (mr *MockCommentRepositoryMockRecorder) Delete(ctx, id any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockCommentRepository)(nil).Delete), ctx, id)
+}
+
 // GetByID mocks base method.
 func (m *MockCommentRepository) GetByID(ctx context.Context, id int) (*domain.Comment, error) {
 	m.ctrl.T.Helper()
@@ -135,6 +149,20 @@ func (m *MockCommentUseCase) AddComment(ctx context.Context, postID int, usernam
 func (mr *MockCommentUseCaseMockRecorder) AddComment(ctx, postID, username, content any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddComment", reflect.TypeOf((*MockCommentUseCase)(nil).AddComment), ctx, postID, username, content)
+}
+
+// DeleteComment mocks base method.
+func (m *MockCommentUseCase) DeleteComment(ctx context.Context, id int, username string) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "DeleteComment", ctx, id, username)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// DeleteComment indicates an expected call of DeleteComment.
+func (mr *MockCommentUseCaseMockRecorder) DeleteComment(ctx, id, username any) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeleteComment", reflect.TypeOf((*MockCommentUseCase)(nil).DeleteComment), ctx, id, username)
 }
 
 // EditComment mocks base method.


### PR DESCRIPTION
## Summary
- Added Delete method to CommentRepository and DeleteComment to CommentUseCase ports.
- Implemented Delete in commentRepository using GORM.
- Implemented DeleteComment in commentUseCase with authorship authorization validation.
- Implemented DeleteComment handler in CommentHandler and registered DELETE /comments/:id route.
- Added unit tests, regenerated mocks and Swagger API documentation.

## Test Plan
- Run automated tests: make check