### PR TITLE
feat: add like_count to GetPostByID response

### DIFF
--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -1377,6 +1377,9 @@ const docTemplate = `{
                 "id": {
                     "type": "integer"
                 },
+                "like_count": {
+                    "type": "integer"
+                },
                 "message": {
                     "type": "string"
                 },

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -1371,6 +1371,9 @@
                 "id": {
                     "type": "integer"
                 },
+                "like_count": {
+                    "type": "integer"
+                },
                 "message": {
                     "type": "string"
                 },

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -143,6 +143,8 @@ definitions:
         type: string
       id:
         type: integer
+      like_count:
+        type: integer
       message:
         type: string
       tags:

--- a/internal/api/dto/post_dto.go
+++ b/internal/api/dto/post_dto.go
@@ -20,6 +20,7 @@ type PostResponse struct {
 	Content   string             `json:"content,omitempty"`
 	Tags      []string           `json:"tags,omitempty"`
 	Author    string             `json:"author,omitempty"`
+	LikeCount int                `json:"like_count"`
 	Comments  []*CommentResponse `json:"comments,omitempty"`
 	CreatedAt time.Time          `json:"created_at"`
 	UpdatedAt time.Time          `json:"updated_at"`

--- a/internal/api/handler/post_handler.go
+++ b/internal/api/handler/post_handler.go
@@ -148,6 +148,7 @@ func (h *PostHandler) GetPostByID(c echo.Context) error {
 		Title:     post.Title,
 		Content:   post.Content,
 		Tags:      post.Tags,
+		LikeCount: post.LikeCount,
 		Comments:  commentsResp,
 		CreatedAt: post.CreatedAt,
 		UpdatedAt: post.UpdatedAt,


### PR DESCRIPTION
## Summary
- Added `LikeCount` field to `dto.PostResponse` struct.
- Mapped `LikeCount` in `GetPostByID` handler.
- Regenerated Swagger API documentation.

## Test Plan
- Ran `make check` (all Go unit tests and linters passed)
- Ran `make docs` (successfully updated Swagger specs)