### PR TITLE
feat: make GET /posts/{id} endpoint public

### DIFF
--- a/api/swagger/docs.go
+++ b/api/swagger/docs.go
@@ -417,18 +417,6 @@ const docTemplate = `{
                             "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/dto.ErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/dto.ErrorResponse"
-                        }
-                    },
                     "404": {
                         "description": "Not Found",
                         "schema": {

--- a/api/swagger/swagger.json
+++ b/api/swagger/swagger.json
@@ -411,18 +411,6 @@
                             "$ref": "#/definitions/dto.ErrorResponse"
                         }
                     },
-                    "401": {
-                        "description": "Unauthorized",
-                        "schema": {
-                            "$ref": "#/definitions/dto.ErrorResponse"
-                        }
-                    },
-                    "403": {
-                        "description": "Forbidden",
-                        "schema": {
-                            "$ref": "#/definitions/dto.ErrorResponse"
-                        }
-                    },
                     "404": {
                         "description": "Not Found",
                         "schema": {

--- a/api/swagger/swagger.yaml
+++ b/api/swagger/swagger.yaml
@@ -517,14 +517,6 @@ paths:
           description: Bad Request
           schema:
             $ref: '#/definitions/dto.ErrorResponse'
-        "401":
-          description: Unauthorized
-          schema:
-            $ref: '#/definitions/dto.ErrorResponse'
-        "403":
-          description: Forbidden
-          schema:
-            $ref: '#/definitions/dto.ErrorResponse'
         "404":
           description: Not Found
           schema:

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -122,12 +122,14 @@ func main() {
 		}
 	}
 
+	// Public Post Routes
+	e.GET("/posts/:id", postHdl.GetPostByID)
+
 	// Posts Group
 	posts := e.Group("/posts", middleware.Authorize(tokenSvc))
 	{
 		posts.POST("", postHdl.CreatePost)
 		posts.GET("", postHdl.GetPosts)
-		posts.GET("/:id", postHdl.GetPostByID)
 		posts.PUT("/:id", postHdl.UpdatePost)
 		posts.DELETE("/:id", postHdl.DeletePost)
 

--- a/internal/api/handler/post_handler.go
+++ b/internal/api/handler/post_handler.go
@@ -97,33 +97,23 @@ func (h *PostHandler) CreatePost(c echo.Context) error {
 //	@Param			id	path		int	true	"Post ID"
 //	@Success		200	{object}	dto.PostResponse
 //	@Failure		400	{object}	dto.ErrorResponse
-//	@Failure		401	{object}	dto.ErrorResponse
-//	@Failure		403	{object}	dto.ErrorResponse
 //	@Failure		404	{object}	dto.ErrorResponse
 //	@Failure		500	{object}	dto.ErrorResponse
 //	@Router			/posts/{id} [get]
 func (h *PostHandler) GetPostByID(c echo.Context) error {
-	username, ok := c.Get("username").(string)
-	if !ok {
-		return c.JSON(http.StatusUnauthorized, dto.ErrorResponse{Error: "Unauthorized"})
-	}
-
 	idStr := c.Param("id")
 	id, err := strconv.Atoi(idStr)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: "Post ID must be a number"})
 	}
 
-	post, err := h.postUseCase.GetPostByID(c.Request().Context(), username, id)
+	post, err := h.postUseCase.GetPostByID(c.Request().Context(), id)
 	if err != nil {
 		if errors.Is(err, domain.ErrPostNotFound) {
 			return c.JSON(http.StatusNotFound, dto.ErrorResponse{Error: "Post not found"})
 		}
 		if errors.Is(err, domain.ErrInvalidPost) {
 			return c.JSON(http.StatusBadRequest, dto.ErrorResponse{Error: "Post ID must be integer and not 0"})
-		}
-		if errors.Is(err, domain.ErrUnauthorized) {
-			return c.JSON(http.StatusForbidden, dto.ErrorResponse{Error: "You do not have permission to access this post"})
 		}
 		return c.JSON(http.StatusInternalServerError, dto.ErrorResponse{Error: "Something went wrong"})
 	}

--- a/internal/api/handler/post_handler_test.go
+++ b/internal/api/handler/post_handler_test.go
@@ -162,4 +162,25 @@ func TestPostHandler_GetPostByID(t *testing.T) {
 		assert.NoError(t, err)
 		assert.Equal(t, http.StatusInternalServerError, rec.Code)
 	})
+
+	t.Run("bad request - invalid post error from usecase", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/posts/1", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath("/posts/:id")
+		c.SetParamNames("id")
+		c.SetParamValues("1")
+
+		mockPostUC.EXPECT().GetPostByID(gomock.Any(), postID).Return(nil, domain.ErrInvalidPost)
+
+		err := h.GetPostByID(c)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+
+		var resp dto.ErrorResponse
+		err = json.Unmarshal(rec.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.Equal(t, "Post ID must be integer and not 0", resp.Error)
+	})
 }

--- a/internal/api/handler/post_handler_test.go
+++ b/internal/api/handler/post_handler_test.go
@@ -1,0 +1,165 @@
+package handler
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/billykore/project-one/internal/api/dto"
+	"github.com/billykore/project-one/internal/core/domain"
+	"github.com/billykore/project-one/internal/core/usecase/mocks"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"go.uber.org/mock/gomock"
+)
+
+func TestPostHandler_GetPostByID(t *testing.T) {
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockPostUC := mocks.NewMockPostUseCase(ctrl)
+	mockCommentUC := mocks.NewMockCommentUseCase(ctrl)
+	mockValidator := mocks.NewMockValidator(ctrl)
+
+	h := NewPostHandler(mockPostUC, mockCommentUC, mockValidator)
+
+	postID := 1
+
+	t.Run("success - authenticated", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/posts/1", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath("/posts/:id")
+		c.SetParamNames("id")
+		c.SetParamValues("1")
+		c.Set("username", "testuser")
+
+		expectedPost := &domain.Post{
+			ID:       postID,
+			Username: "authoruser",
+			Title:    "Post Title",
+			Content:  "Post Content",
+			Tags:     []string{"tag1"},
+		}
+		expectedComments := []*domain.Comment{
+			{
+				ID:       1,
+				Username: "commenter",
+				Content:  "Nice post!",
+			},
+		}
+
+		mockPostUC.EXPECT().GetPostByID(gomock.Any(), postID).Return(expectedPost, nil)
+		mockCommentUC.EXPECT().GetCommentsByPostID(gomock.Any(), postID).Return(expectedComments, nil)
+
+		err := h.GetPostByID(c)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp dto.PostResponse
+		err = json.Unmarshal(rec.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.Equal(t, postID, resp.ID)
+		assert.Equal(t, "authoruser", resp.Author)
+		assert.Len(t, resp.Comments, 1)
+		assert.Equal(t, "commenter", resp.Comments[0].Username)
+	})
+
+	t.Run("success - unauthenticated", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/posts/1", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath("/posts/:id")
+		c.SetParamNames("id")
+		c.SetParamValues("1")
+
+		expectedPost := &domain.Post{
+			ID:       postID,
+			Username: "authoruser",
+			Title:    "Post Title",
+			Content:  "Post Content",
+		}
+
+		mockPostUC.EXPECT().GetPostByID(gomock.Any(), postID).Return(expectedPost, nil)
+		mockCommentUC.EXPECT().GetCommentsByPostID(gomock.Any(), postID).Return([]*domain.Comment{}, nil)
+
+		err := h.GetPostByID(c)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusOK, rec.Code)
+
+		var resp dto.PostResponse
+		err = json.Unmarshal(rec.Body.Bytes(), &resp)
+		assert.NoError(t, err)
+		assert.Equal(t, postID, resp.ID)
+		assert.Equal(t, "authoruser", resp.Author)
+		assert.Empty(t, resp.Comments)
+	})
+
+	t.Run("bad request - invalid post id format", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/posts/invalid", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath("/posts/:id")
+		c.SetParamNames("id")
+		c.SetParamValues("invalid")
+
+		err := h.GetPostByID(c)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusBadRequest, rec.Code)
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/posts/1", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath("/posts/:id")
+		c.SetParamNames("id")
+		c.SetParamValues("1")
+
+		mockPostUC.EXPECT().GetPostByID(gomock.Any(), postID).Return(nil, domain.ErrPostNotFound)
+
+		err := h.GetPostByID(c)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusNotFound, rec.Code)
+	})
+
+	t.Run("internal server error - post usecase error", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/posts/1", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath("/posts/:id")
+		c.SetParamNames("id")
+		c.SetParamValues("1")
+
+		mockPostUC.EXPECT().GetPostByID(gomock.Any(), postID).Return(nil, errors.New("usecase error"))
+
+		err := h.GetPostByID(c)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	})
+
+	t.Run("internal server error - comments error", func(t *testing.T) {
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/posts/1", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath("/posts/:id")
+		c.SetParamNames("id")
+		c.SetParamValues("1")
+
+		expectedPost := &domain.Post{ID: postID}
+		mockPostUC.EXPECT().GetPostByID(gomock.Any(), postID).Return(expectedPost, nil)
+		mockCommentUC.EXPECT().GetCommentsByPostID(gomock.Any(), postID).Return(nil, errors.New("comment error"))
+
+		err := h.GetPostByID(c)
+		assert.NoError(t, err)
+		assert.Equal(t, http.StatusInternalServerError, rec.Code)
+	})
+}

--- a/internal/core/ports/post.go
+++ b/internal/core/ports/post.go
@@ -28,8 +28,8 @@ type PostRepository interface {
 type PostUseCase interface {
 	// CreatePost creates a new post with the given details.
 	CreatePost(ctx context.Context, username string, title, content string, tags []string) (*domain.Post, error)
-	// GetPostByID retrieves a post by its ID for a specific user.
-	GetPostByID(ctx context.Context, username string, postID int) (*domain.Post, error)
+	// GetPostByID retrieves a post by its ID.
+	GetPostByID(ctx context.Context, postID int) (*domain.Post, error)
 	// GetPosts retrieves all posts for a specific user.
 	GetPosts(ctx context.Context, username string, limit, offset int) ([]*domain.Post, error)
 	// UpdatePost updates an existing post for a specific user.

--- a/internal/core/usecase/mocks/mock_post.go
+++ b/internal/core/usecase/mocks/mock_post.go
@@ -212,18 +212,18 @@ func (mr *MockPostUseCaseMockRecorder) GetLikeStatus(ctx, postID, username any) 
 }
 
 // GetPostByID mocks base method.
-func (m *MockPostUseCase) GetPostByID(ctx context.Context, username string, postID int) (*domain.Post, error) {
+func (m *MockPostUseCase) GetPostByID(ctx context.Context, postID int) (*domain.Post, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetPostByID", ctx, username, postID)
+	ret := m.ctrl.Call(m, "GetPostByID", ctx, postID)
 	ret0, _ := ret[0].(*domain.Post)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetPostByID indicates an expected call of GetPostByID.
-func (mr *MockPostUseCaseMockRecorder) GetPostByID(ctx, username, postID any) *gomock.Call {
+func (mr *MockPostUseCaseMockRecorder) GetPostByID(ctx, postID any) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPostByID", reflect.TypeOf((*MockPostUseCase)(nil).GetPostByID), ctx, username, postID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetPostByID", reflect.TypeOf((*MockPostUseCase)(nil).GetPostByID), ctx, postID)
 }
 
 // GetPosts mocks base method.

--- a/internal/core/usecase/post_usecase.go
+++ b/internal/core/usecase/post_usecase.go
@@ -50,17 +50,17 @@ func (uc *postUseCase) CreatePost(ctx context.Context, username string, title, c
 	return post, nil
 }
 
-func (uc *postUseCase) GetPostByID(ctx context.Context, username string, id int) (*domain.Post, error) {
+func (uc *postUseCase) GetPostByID(ctx context.Context, id int) (*domain.Post, error) {
 	if id <= 0 {
 		return nil, domain.ErrInvalidPost
 	}
 
-	post, err := uc.postRepo.GetByID(ctx, username, id)
+	post, err := uc.postRepo.GetByIDOnly(ctx, id)
 	if err != nil {
 		if errors.Is(err, domain.ErrPostNotFound) {
 			return nil, err
 		}
-		uc.log.Error(ctx, "failed to get post by id", "postID", id, "username", username, "error", err)
+		uc.log.Error(ctx, "failed to get post by id", "postID", id, "error", err)
 		return nil, domain.ErrInternalServer
 	}
 

--- a/internal/core/usecase/post_usecase_test.go
+++ b/internal/core/usecase/post_usecase_test.go
@@ -73,18 +73,18 @@ func TestPostUseCase_GetPostByID(t *testing.T) {
 
 	t.Run("success", func(t *testing.T) {
 		expectedPost := &domain.Post{ID: postID, Username: username, Title: "Test Title"}
-		mockRepo.EXPECT().GetByID(ctx, username, postID).Return(expectedPost, nil)
+		mockRepo.EXPECT().GetByIDOnly(ctx, postID).Return(expectedPost, nil)
 
-		post, err := svc.GetPostByID(ctx, username, postID)
+		post, err := svc.GetPostByID(ctx, postID)
 
 		assert.NoError(t, err)
 		assert.Equal(t, expectedPost, post)
 	})
 
 	t.Run("not found", func(t *testing.T) {
-		mockRepo.EXPECT().GetByID(ctx, username, postID).Return(nil, domain.ErrPostNotFound)
+		mockRepo.EXPECT().GetByIDOnly(ctx, postID).Return(nil, domain.ErrPostNotFound)
 
-		post, err := svc.GetPostByID(ctx, username, postID)
+		post, err := svc.GetPostByID(ctx, postID)
 
 		assert.Error(t, err)
 		assert.Nil(t, post)
@@ -92,10 +92,10 @@ func TestPostUseCase_GetPostByID(t *testing.T) {
 	})
 
 	t.Run("repository error", func(t *testing.T) {
-		mockRepo.EXPECT().GetByID(ctx, username, postID).Return(nil, errors.New("db error"))
-		mockLog.EXPECT().Error(ctx, "failed to get post by id", "postID", postID, "username", username, "error", gomock.Any())
+		mockRepo.EXPECT().GetByIDOnly(ctx, postID).Return(nil, errors.New("db error"))
+		mockLog.EXPECT().Error(ctx, "failed to get post by id", "postID", postID, "error", gomock.Any())
 
-		post, err := svc.GetPostByID(ctx, username, postID)
+		post, err := svc.GetPostByID(ctx, postID)
 
 		assert.Error(t, err)
 		assert.Nil(t, post)
@@ -103,7 +103,7 @@ func TestPostUseCase_GetPostByID(t *testing.T) {
 	})
 
 	t.Run("invalid id", func(t *testing.T) {
-		post, err := svc.GetPostByID(ctx, username, 0)
+		post, err := svc.GetPostByID(ctx, 0)
 
 		assert.Error(t, err)
 		assert.Nil(t, post)


### PR DESCRIPTION
## Summary
- Changed the signature and usecase implementation of `GetPostByID` to remove `username` and fetch posts publicly via `GetByIDOnly` repository method.
- Regenerated mock files (`mock_post.go`) to reflect the updated usecase interface.
- Exposed route `GET /posts/:id` publicly in `cmd/main.go` and verified Swagger docs updates. Added unit tests for the public handler and error mapping.

## Test Plan
- Run `make check` to ensure all tests, linter, and code style checks pass successfully.

Closes #75 